### PR TITLE
Set the type of data returned by the functions

### DIFF
--- a/src/Console/stubs/user-resource.stub
+++ b/src/Console/stubs/user-resource.stub
@@ -18,7 +18,7 @@ class User extends RestResource
      * @param RestRequest $request
      * @return array
      */
-    public function fields(\Lomkit\Rest\Http\Requests\RestRequest $request)
+    public function fields(\Lomkit\Rest\Http\Requests\RestRequest $request): array
     {
         return [
             'id',
@@ -32,7 +32,7 @@ class User extends RestResource
      * @param RestRequest $request
      * @return array
      */
-    public function relations(\Lomkit\Rest\Http\Requests\RestRequest $request)
+    public function relations(\Lomkit\Rest\Http\Requests\RestRequest $request): array
     {
         return [];
     }
@@ -42,7 +42,8 @@ class User extends RestResource
      * @param RestRequest $request
      * @return array
      */
-    public function scopes(\Lomkit\Rest\Http\Requests\RestRequest $request) {
+    public function scopes(\Lomkit\Rest\Http\Requests\RestRequest $request): array
+    {
         return [];
     }
 
@@ -51,7 +52,8 @@ class User extends RestResource
      * @param RestRequest $request
      * @return array
      */
-    public function limits(\Lomkit\Rest\Http\Requests\RestRequest $request) {
+    public function limits(\Lomkit\Rest\Http\Requests\RestRequest $request): array
+    {
         return [
             10,
             25,
@@ -64,7 +66,8 @@ class User extends RestResource
      * @param RestRequest $request
      * @return array
      */
-    public function actions(RestRequest $request): array {
+    public function actions(\Lomkit\Rest\Http\Requests\RestRequest $request): array
+    {
         return [];
     }
 }


### PR DESCRIPTION
When using the command "php artisan rest:quick-start" a file called "UserResource.php" will be generated, it does not have the return type in its functions and it sends me an error of the type:

```
{
    "message": "Declaration of App\\Rest\\Resources\\User::relations(Lomkit\\Rest\\Http\\Requests\\RestRequest $request) must be compatible with Lomkit\\Rest\\Http\\Resource::relations(Lomkit\\Rest\\Http\\Requests\\RestRequest $request): array",
    "exception": "Symfony\\Component\\ErrorHandler\\Error\\FatalError",
    "file": "/var/www/html/app/Rest/Resources/UserResource.php",
    "line": 35,
    "trace": []
}
```