### PR TITLE
Fixed wrong matching. Changed match detail to details for working openAPI

### DIFF
--- a/src/Console/Commands/DocumentationCommand.php
+++ b/src/Console/Commands/DocumentationCommand.php
@@ -45,7 +45,7 @@ class DocumentationCommand extends GeneratorCommand implements PromptsForMissing
         );
 
         $this->info('The documentation was generated successfully!');
-        $this->info('Open '.url(config('rest.documentation.routing.path')).'in a web browser.');
+        $this->info('Open '.url(config('rest.documentation.routing.path')).' in a web browser.');
     }
 
     /**

--- a/src/Documentation/Schemas/OpenAPI.php
+++ b/src/Documentation/Schemas/OpenAPI.php
@@ -267,12 +267,12 @@ class OpenAPI extends Schema
             if ($controller instanceof Controller) {
                 $path = match (Str::afterLast($route->getName(), '.')) {
                     'details'      => (new Path())->generateDetailAndDestroy($controller),
-                    'search'      => (new Path())->generateSearch($controller),
-                    'mutate'      => (new Path())->generateMutate($controller),
-                    'operate'     => (new Path())->generateActions($controller),
-                    'restore'     => (new Path())->generateRestore($controller),
-                    'forceDelete' => (new Path())->generateForceDelete($controller),
-                    default       => null
+                    'search'       => (new Path())->generateSearch($controller),
+                    'mutate'       => (new Path())->generateMutate($controller),
+                    'operate'      => (new Path())->generateActions($controller),
+                    'restore'      => (new Path())->generateRestore($controller),
+                    'forceDelete'  => (new Path())->generateForceDelete($controller),
+                    default        => null
                 };
 
                 if (!is_null($path)) {

--- a/src/Documentation/Schemas/OpenAPI.php
+++ b/src/Documentation/Schemas/OpenAPI.php
@@ -266,7 +266,7 @@ class OpenAPI extends Schema
 
             if ($controller instanceof Controller) {
                 $path = match (Str::afterLast($route->getName(), '.')) {
-                    'detail'      => (new Path())->generateDetailAndDestroy($controller),
+                    'details'      => (new Path())->generateDetailAndDestroy($controller),
                     'search'      => (new Path())->generateSearch($controller),
                     'mutate'      => (new Path())->generateMutate($controller),
                     'operate'     => (new Path())->generateActions($controller),


### PR DESCRIPTION
There was a missing "s" inside of the OpenAPI `generatePaths` function. 

The function tried to match the string 'detail' but it never appeared with the default route names via `Rest::resource('users', UsersController::class);`

`php artisan route:list` -> 
```
GET|HEAD  api/v1/users ... api.v1.users.details › App\Rest\Controllers\UsersController@details
  DELETE    api/v1/users ... api.v1.users.destroy › App\Rest\Controllers\UsersController@destroy
  POST      api/v1/users/actions/{action} ... api.v1.users.operate › App\Rest\Controllers\UsersController@operate
  POST      api/v1/users/mutate ... api.v1.users.mutate › App\Rest\Controllers\UsersController@mutate
  POST      api/v1/users/search ... api.v1.users.search › App\Rest\Controllers\UsersController@search
  ```
Before fix:
![image](https://github.com/Lomkit/laravel-rest-api/assets/140813072/a3f67414-2dad-4c8c-b2cc-fae17be30e46)

After fix:
![image](https://github.com/Lomkit/laravel-rest-api/assets/140813072/20f67f23-547f-4a7b-aaf1-a0ff0e4aad85)


I also added a space after the url inside the `rest:documentation` command info. 