### PR TITLE
statsable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Here is a quick look at what you can do using API search method:
           }
         ],
         "gates": ["create", "view"],
+        "stats": true,
         "page": 2,
         "limit": 10
     }

--- a/src/Concerns/Statsable.php
+++ b/src/Concerns/Statsable.php
@@ -2,7 +2,6 @@
 
 namespace Lomkit\Rest\Concerns;
 
-
 trait Statsable
 {
     /**

--- a/src/Concerns/Statsable.php
+++ b/src/Concerns/Statsable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lomkit\Rest\Concerns;
+
+
+trait Statsable
+{
+    /**
+     * Custom stats resource.
+     *
+     * @param \Illuminate\Contracts\Database\Eloquent\Builder $query
+     *
+     * @return array
+     */
+    public function stats(\Illuminate\Contracts\Database\Eloquent\Builder $query): array
+    {
+        return [];
+    }
+}

--- a/src/Http/Resource.php
+++ b/src/Http/Resource.php
@@ -13,6 +13,7 @@ use Lomkit\Rest\Concerns\Resource\HasResourceHooks;
 use Lomkit\Rest\Concerns\Resource\Paginable;
 use Lomkit\Rest\Concerns\Resource\Relationable;
 use Lomkit\Rest\Concerns\Resource\Rulable;
+use Lomkit\Rest\Concerns\Statsable;
 use Lomkit\Rest\Http\Requests\RestRequest;
 use Lomkit\Rest\Instructions\Instructionable;
 
@@ -28,6 +29,7 @@ class Resource implements \JsonSerializable
     use Actionable;
     use Instructionable;
     use HasResourceHooks;
+    use Statsable;
 
     /**
      * The model the entry corresponds to.

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -152,13 +152,13 @@ class Response implements Responsable
     {
         $meta = [];
 
-        if($this->resource->isGatingEnabled() && in_array('create', $request->input('search.gates', []))) {
+        if ($this->resource->isGatingEnabled() && in_array('create', $request->input('search.gates', []))) {
             $meta = array_merge($meta, [config('rest.gates.key') => [
                 config('rest.gates.names.authorized_to_create') => $this->resource->authorizedTo('create', $this->resource::newModel()::class),
             ]]);
         }
 
-        if((bool) $request->input('search.stats')) {
+        if ((bool) $request->input('search.stats')) {
             $query = app()->make(QueryBuilder::class, ['resource' => $this->resource, 'query' => null])->search($request->input('search', []));
             $meta = array_merge($meta, ['stats' => $this->resource->stats($query)]);
         }


### PR DESCRIPTION
When we want to extend filters and interactions in resource with stats data

PostResource
```php
public function stats(\Illuminate\Contracts\Database\Eloquent\Builder $query): array
{
    return [
        'posts_has_approved_comments' => $query->whereHas('comments', fn($q) => $q->where('approved', true))->count(),
        'posts_has_worse_comments' => $query->whereHas('comments', fn($q) => $q->where('star', '<', 3))->count(),
        'published' => $query->where('published', true)->count(),
    ];
}
```
Request `[POST] api/posts/search`
```json
{
  "search": {
    "stats": true,
    ...
  }
}
```
Response
```json
{
    "current_page": 1,
    "data": [...],
    "from": 1,
    "last_page": 1,
    "per_page": 50,
    "to": 10,
    "total": 10,
    "meta": {
        "stats": {
            "posts_has_approved_comments": 5,
            "posts_has_worse_comments": 2,
            "published": 9,
        }
    }
}
```