### PR TITLE
Fixed Rest facade docblock

### DIFF
--- a/src/Facades/Rest.php
+++ b/src/Facades/Rest.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Facades\Facade;
 class Rest extends Facade
 {
     /**
+     * Get the registered name of the component.
+     *
      * @return string
      */
     protected static function getFacadeAccessor()

--- a/src/Facades/Rest.php
+++ b/src/Facades/Rest.php
@@ -4,13 +4,16 @@ namespace Lomkit\Rest\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static \Lomkit\Rest\Http\Routing\PendingResourceRegistration resource(string $name, $controller, array $options = [])
+ * @method static \Lomkit\Rest\Rest                                     withDocumentationCallback(\Closure $documentationCallback)
+ *
+ * @see \Lomkit\Rest\Rest
+ */
 class Rest extends Facade
 {
     /**
-     * @method static \Lomkit\Rest\Http\Routing\PendingResourceRegistration resource(string $name, $controller, array $options = [])
-     * @method static \Lomkit\Rest\Rest                                     withDocumentationCallback(\Closure $documentationCallback)
-     *
-     * @see \Lomkit\Rest\Rest
+     * @return string
      */
     protected static function getFacadeAccessor()
     {


### PR DESCRIPTION
The facade methods were documented on top of the `getFacadeAccessor` method so the methods weren't picked up by intellisense.