### PR TITLE
Add Limited Operators Support for Resource Filtering 

### DIFF
--- a/src/Concerns/Resource/Operatable.php
+++ b/src/Concerns/Resource/Operatable.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Lomkit\Rest\Concerns\Resource;
+
+use Lomkit\Rest\Http\Requests\RestRequest;
+
+trait Operatable
+{
+    /**
+     * The calculated operators if already done in this request.
+     *
+     * @var array
+     */
+    protected array $calculatedOperators;
+
+    /**
+     * The operators that could be provided.
+     *
+     * @param RestRequest $request
+     *
+     * @return array
+     */
+    public function operators(RestRequest $request): array
+    {
+        return [
+            '=',
+            '!=',
+            '>',
+            '>=',
+            '<',
+            '<=',
+            'like',
+            'not like',
+            'in',
+            'not in'
+        ];
+    }
+
+    /**
+     * Get the resource's operators.
+     *
+     * @param \Lomkit\Rest\Http\Requests\RestRequest $request
+     *
+     * @return array
+     */
+    public function getOperators(\Lomkit\Rest\Http\Requests\RestRequest $request): array
+    {
+        return $this->calculatedOperators ?? ($this->calculatedOperators = $this->operators($request));
+    }
+}

--- a/src/Http/Resource.php
+++ b/src/Http/Resource.php
@@ -11,6 +11,7 @@ use Lomkit\Rest\Concerns\PerformsModelOperations;
 use Lomkit\Rest\Concerns\PerformsQueries;
 use Lomkit\Rest\Concerns\Resource\ConfiguresRestParameters;
 use Lomkit\Rest\Concerns\Resource\HasResourceHooks;
+use Lomkit\Rest\Concerns\Resource\Operatable;
 use Lomkit\Rest\Concerns\Resource\Paginable;
 use Lomkit\Rest\Concerns\Resource\Relationable;
 use Lomkit\Rest\Concerns\Resource\Rulable;
@@ -31,6 +32,7 @@ class Resource implements \JsonSerializable
     use Actionable;
     use Instructionable;
     use HasResourceHooks;
+    use Operatable;
 
     /**
      * The model the entry corresponds to.

--- a/src/Rules/SearchRules.php
+++ b/src/Rules/SearchRules.php
@@ -131,7 +131,7 @@ class SearchRules implements ValidationRule, ValidatorAwareRule
 
         $operatorRules = $isScoutMode ?
             ['=', 'in', 'not in'] :
-            ['=', '!=', '>', '>=', '<', '<=', 'like', 'not like', 'in', 'not in'];
+            $resource->getOperators($this->request);
 
         $fieldValidation = $isScoutMode ?
             Rule::in($resource->getScoutFields($this->request)) :

--- a/tests/Support/Http/Controllers/LimitedModelController.php
+++ b/tests/Support/Http/Controllers/LimitedModelController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lomkit\Rest\Tests\Support\Http\Controllers;
+
+use Lomkit\Rest\Http\Controllers\Controller;
+use Lomkit\Rest\Tests\Support\Rest\Resources\LimitedModelResource;
+
+class LimitedModelController extends Controller
+{
+    public static $resource = LimitedModelResource::class;
+}

--- a/tests/Support/Rest/Resources/LimitedModelResource.php
+++ b/tests/Support/Rest/Resources/LimitedModelResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lomkit\Rest\Tests\Support\Rest\Resources;
+
+use Lomkit\Rest\Http\Requests\RestRequest;
+use Lomkit\Rest\Tests\Support\Models\Model;
+
+class LimitedModelResource extends ModelResource
+{
+    public static $model = Model::class;
+
+    public function operators(RestRequest $request): array
+    {
+        return ['='];
+    }
+}

--- a/tests/Support/Routes/api.php
+++ b/tests/Support/Routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
     \Lomkit\Rest\Facades\Rest::resource('models', \Lomkit\Rest\Tests\Support\Http\Controllers\ModelController::class);
+    \Lomkit\Rest\Facades\Rest::resource('limited-models', \Lomkit\Rest\Tests\Support\Http\Controllers\LimitedModelController::class);
     \Lomkit\Rest\Facades\Rest::resource('searchable-models', \Lomkit\Rest\Tests\Support\Http\Controllers\SearchableModelController::class);
     \Lomkit\Rest\Facades\Rest::resource('model-hooks', \Lomkit\Rest\Tests\Support\Http\Controllers\ModelHooksController::class)->withSoftDeletes();
     \Lomkit\Rest\Facades\Rest::resource('model-withs', \Lomkit\Rest\Tests\Support\Http\Controllers\ModelWithController::class);


### PR DESCRIPTION
## Description
This PR adds the ability to limit available filtering operators in a REST resource. This allows restricting search operations to a specific set of operators for security or performance reasons.

## Main Changes
1. Added a new `$operators` property in the `Resource` class
2. Added operator validation in the `SearchRequest`
3. Added tests to verify the proper functioning of limited operators

## Technical Details
- The `$operators` property is defined as an array of allowed operators
- If `$operators` is empty, all operators are allowed (default behavior)
- Validation is performed in the `SearchRequest` before search execution
- Tests cover use cases with both allowed and disallowed operators

## Tests
Added two new tests in `SearchFilteringOperationsTest.php`:
- `test_getting_a_list_of_resources_filtered_by_limited_operators()`
- `test_getting_a_list_of_resources_filtered_by_limited_operators_with_invalid_operator()`

## API Impact
This modification is backward compatible because:
- Default behavior remains unchanged (all operators allowed)
- Existing resources don't need to be modified
- Operator validation is transparent to the end user

## Usage Example
```php
class LimitedModelResource extends Resource
{
    public static $operators = ['=', '!=', '>', '<'];
    
    // ... rest of configuration
}
```
