### PR TITLE
Dynamic binding gates

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -32,12 +32,9 @@ class Response implements Responsable
 
     protected function buildGatesForModel(Model $model, Resource $resource, array $gates)
     {
-        return array_merge(
-            in_array('view', $gates) ? [config('rest.gates.names.authorized_to_view')         => $resource->authorizedTo('view', $model)] : [],
-            in_array('update', $gates) ? [config('rest.gates.names.authorized_to_update')         => $resource->authorizedTo('update', $model)] : [],
-            in_array('delete', $gates) ? [config('rest.gates.names.authorized_to_delete')         => $resource->authorizedTo('delete', $model)] : [],
-            in_array('restore', $gates) ? [config('rest.gates.names.authorized_to_restore')         => $resource->authorizedTo('restore', $model)] : [],
-            in_array('forceDelete', $gates) ? [config('rest.gates.names.authorized_to_force_delete')         => $resource->authorizedTo('forceDelete', $model)] : [],
+        return array_combine(
+            array_map(fn($gate) => config("rest.gates.names.authorized_to_{$gate}", "authorized_to_{$gate}"), $gates),
+            array_map(fn($gate) => $resource->authorizedTo($gate, $model), $gates)
         );
     }
 

--- a/src/Rules/SearchRules.php
+++ b/src/Rules/SearchRules.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Http\Client\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
+use Illuminate\Support\Facades\Gate;
 use Lomkit\Rest\Http\Requests\RestRequest;
 use Lomkit\Rest\Http\Resource;
 
@@ -68,6 +69,10 @@ class SearchRules implements ValidationRule, ValidatorAwareRule
             $attribute .= '.';
         }
 
+        $policy = Gate::getPolicyFor($this->resource::$model);
+        $validGates = $policy ? get_class_methods($policy) : [];
+        $validGates = array_filter($validGates, fn($method) => !in_array($method, ['before', 'after']));
+
         $this
             ->validator
             ->setRules(
@@ -89,7 +94,7 @@ class SearchRules implements ValidationRule, ValidatorAwareRule
                     [
                         $attribute.'limit' => ['sometimes', 'integer', Rule::in($this->resource->getLimits($this->request))],
                         $attribute.'page'  => ['sometimes', 'integer'],
-                        $attribute.'gates' => ['sometimes', 'array', Rule::in(['viewAny', 'view', 'create', 'update', 'delete', 'restore', 'forceDelete'])],
+                        $attribute.'gates' => ['sometimes', 'array', Rule::in($validGates)],
                     ],
                     $this->isRootSearchRules ? [$attribute.'includes' => ['sometimes', 'array']] : [],
                     $this->isRootSearchRules ? $this->includesRules($this->resource, $attribute.'includes') : [],

--- a/src/Rules/SearchRules.php
+++ b/src/Rules/SearchRules.php
@@ -71,7 +71,7 @@ class SearchRules implements ValidationRule, ValidatorAwareRule
 
         $policy = Gate::getPolicyFor($this->resource::$model);
         $validGates = $policy ? get_class_methods($policy) : [];
-        $validGates = array_filter($validGates, fn($method) => !in_array($method, ['before', 'after']));
+        $validGates = array_filter($validGates, fn($method) => !in_array($method, ['before', 'after', '__call', '__construct']));
 
         $this
             ->validator


### PR DESCRIPTION
closes #156 

The purpose of this PR is to automatically bind all the gates of a model (before, only the view, viewAny, delete, restore... methods were available).

It will therefore be possible to add a new authorization (e.g. whether or not the user has the right to download the resource).

What's more, if the gate doesn't have a name in the configuration file, I've made sure to generate one automatically.

It would be a good idea to update the documentation to explain this.

I look forward to your feedback on this feature :)