### PR TITLE
Define default limit

### DIFF
--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -17,11 +17,13 @@ trait Paginable
      */
     public function paginate($query, RestRequest $request)
     {
+        $defaultLimit = $this->defaultLimit ?? 50;
+
         // In case we have a scout builder
         if ($query instanceof Builder) {
-            return $query->paginate($request->input('search.limit', 50), 'page', $request->input('search.page', 1));
+            return $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
         }
 
-        return $query->paginate($request->input('search.limit', 50), ['*'], 'page', $request->input('search.page', 1));
+        return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));
     }
 }

--- a/src/Console/stubs/resource.stub
+++ b/src/Console/stubs/resource.stub
@@ -14,6 +14,13 @@ class {{ class }} extends RestResource
     public static $model = \{{ namespacedModel }}::class;
 
     /**
+     * The default value for the pagination limit
+     *
+     * @var int
+     */
+    protected int $defaultLimit = 50;
+
+    /**
      * The exposed fields that could be provided
      * @param RestRequest $request
      * @return array

--- a/src/Console/stubs/resource.stub
+++ b/src/Console/stubs/resource.stub
@@ -18,7 +18,7 @@ class {{ class }} extends RestResource
      *
      * @var int
      */
-    protected int $defaultLimit = 50;
+    public int $defaultLimit = 50;
 
     /**
      * The exposed fields that could be provided

--- a/src/Console/stubs/resource.stub
+++ b/src/Console/stubs/resource.stub
@@ -14,7 +14,7 @@ class {{ class }} extends RestResource
     public static $model = \{{ namespacedModel }}::class;
 
     /**
-     * The default value for the pagination limit
+     * The default value for the pagination limit.
      *
      * @var int
      */

--- a/src/Console/stubs/user-resource.stub
+++ b/src/Console/stubs/user-resource.stub
@@ -18,7 +18,7 @@ class UserResource extends RestResource
      *
      * @var int
      */
-    protected int $defaultLimit = 50;
+    public int $defaultLimit = 50;
 
     /**
      * The exposed fields that could be provided

--- a/src/Console/stubs/user-resource.stub
+++ b/src/Console/stubs/user-resource.stub
@@ -14,7 +14,7 @@ class UserResource extends RestResource
     public static $model = \App\User::class;
 
     /**
-     * The default value for the pagination limit
+     * The default value for the pagination limit.
      *
      * @var int
      */

--- a/src/Console/stubs/user-resource.stub
+++ b/src/Console/stubs/user-resource.stub
@@ -14,6 +14,13 @@ class UserResource extends RestResource
     public static $model = \App\User::class;
 
     /**
+     * The default value for the pagination limit
+     *
+     * @var int
+     */
+    protected int $defaultLimit = 50;
+
+    /**
      * The exposed fields that could be provided
      * @param RestRequest $request
      * @return array

--- a/src/Http/Resource.php
+++ b/src/Http/Resource.php
@@ -51,7 +51,7 @@ class Resource implements \JsonSerializable
      *
      * @var int
      */
-    protected int $defaultLimit = 50;
+    public int $defaultLimit = 50;
 
     /**
      * Get a fresh instance of the model represented by the resource.

--- a/src/Http/Resource.php
+++ b/src/Http/Resource.php
@@ -47,7 +47,7 @@ class Resource implements \JsonSerializable
     public static $response = Response::class;
 
     /**
-     * The default value for the pagination limit
+     * The default value for the pagination limit.
      *
      * @var int
      */

--- a/src/Http/Resource.php
+++ b/src/Http/Resource.php
@@ -47,6 +47,13 @@ class Resource implements \JsonSerializable
     public static $response = Response::class;
 
     /**
+     * The default value for the pagination limit
+     *
+     * @var int
+     */
+    protected int $defaultLimit = 50;
+
+    /**
      * Get a fresh instance of the model represented by the resource.
      *
      * @return Model

--- a/src/Query/ScoutBuilder.php
+++ b/src/Query/ScoutBuilder.php
@@ -49,7 +49,8 @@ class ScoutBuilder implements QueryBuilder
             $this->applyInstructions($parameters['instructions']);
         });
 
-        $this->queryBuilder->take($parameters['limit'] ?? 50);
+        $defaultLimit = $this->resource->defaultLimit ?? 50;
+        $this->queryBuilder->take($parameters['limit'] ?? $defaultLimit);
 
         $this->queryBuilder
             ->query(function (Builder $query) use ($parameters) {

--- a/tests/Feature/Controllers/SearchPaginateOperationsTest.php
+++ b/tests/Feature/Controllers/SearchPaginateOperationsTest.php
@@ -43,7 +43,7 @@ class SearchPaginateOperationsTest extends TestCase
             '/api/models/search',
             [
                 'search' => [
-                    'page' => 2,
+                    'page'  => 2,
                     'limit' => 1,
                 ],
             ],
@@ -69,7 +69,7 @@ class SearchPaginateOperationsTest extends TestCase
             '/api/models/search',
             [
                 'search' => [
-                    'page' => 101,
+                    'page'  => 101,
                     'limit' => 1,
                 ],
             ],
@@ -100,5 +100,4 @@ class SearchPaginateOperationsTest extends TestCase
         $response->assertJsonPath('last_page', 4);
         $response->assertJsonCount(32, 'data');
     }
-
 }

--- a/tests/Feature/Controllers/SearchPaginateOperationsTest.php
+++ b/tests/Feature/Controllers/SearchPaginateOperationsTest.php
@@ -90,7 +90,7 @@ class SearchPaginateOperationsTest extends TestCase
         Gate::policy(Model::class, GreenPolicy::class);
 
         $response = $this->post(
-            '/api/models/search',
+            '/api/model-with-default-limit/search',
             [],
             ['Accept' => 'application/json']
         );

--- a/tests/Feature/Controllers/SearchPaginateOperationsTest.php
+++ b/tests/Feature/Controllers/SearchPaginateOperationsTest.php
@@ -43,7 +43,7 @@ class SearchPaginateOperationsTest extends TestCase
             '/api/models/search',
             [
                 'search' => [
-                    'page'  => 2,
+                    'page' => 2,
                     'limit' => 1,
                 ],
             ],
@@ -69,7 +69,7 @@ class SearchPaginateOperationsTest extends TestCase
             '/api/models/search',
             [
                 'search' => [
-                    'page'  => 101,
+                    'page' => 101,
                     'limit' => 1,
                 ],
             ],
@@ -82,4 +82,23 @@ class SearchPaginateOperationsTest extends TestCase
             new ModelResource()
         );
     }
+
+    public function test_to_get_a_list_of_paginated_resources_from_the_default_limit(): void
+    {
+        ModelFactory::new()->count(100)->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('per_page', 32);
+        $response->assertJsonPath('last_page', 4);
+        $response->assertJsonCount(32, 'data');
+    }
+
 }

--- a/tests/Support/Http/Controllers/ModelWithDefaultLimitController.php
+++ b/tests/Support/Http/Controllers/ModelWithDefaultLimitController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lomkit\Rest\Tests\Support\Http\Controllers;
+
+use Lomkit\Rest\Http\Controllers\Controller;
+use Lomkit\Rest\Tests\Support\Rest\Resources\ModelWithDefaultLimitResource;
+use Lomkit\Rest\Tests\Support\Rest\Resources\ModelWithResource;
+
+class ModelWithDefaultLimitController extends Controller
+{
+    public static $resource = ModelWithDefaultLimitResource::class;
+}

--- a/tests/Support/Http/Controllers/ModelWithDefaultLimitController.php
+++ b/tests/Support/Http/Controllers/ModelWithDefaultLimitController.php
@@ -4,7 +4,6 @@ namespace Lomkit\Rest\Tests\Support\Http\Controllers;
 
 use Lomkit\Rest\Http\Controllers\Controller;
 use Lomkit\Rest\Tests\Support\Rest\Resources\ModelWithDefaultLimitResource;
-use Lomkit\Rest\Tests\Support\Rest\Resources\ModelWithResource;
 
 class ModelWithDefaultLimitController extends Controller
 {

--- a/tests/Support/Rest/Resources/ModelResource.php
+++ b/tests/Support/Rest/Resources/ModelResource.php
@@ -31,7 +31,7 @@ class ModelResource extends Resource
     use DisableGates;
 
     public static $model = Model::class;
-    
+
     public function createRules(RestRequest $request)
     {
         return [

--- a/tests/Support/Rest/Resources/ModelResource.php
+++ b/tests/Support/Rest/Resources/ModelResource.php
@@ -31,9 +31,7 @@ class ModelResource extends Resource
     use DisableGates;
 
     public static $model = Model::class;
-
-    public int $defaultLimit = 32;
-
+    
     public function createRules(RestRequest $request)
     {
         return [

--- a/tests/Support/Rest/Resources/ModelResource.php
+++ b/tests/Support/Rest/Resources/ModelResource.php
@@ -32,6 +32,8 @@ class ModelResource extends Resource
 
     public static $model = Model::class;
 
+    protected int $defaultLimit = 32;
+
     public function createRules(RestRequest $request)
     {
         return [

--- a/tests/Support/Rest/Resources/ModelResource.php
+++ b/tests/Support/Rest/Resources/ModelResource.php
@@ -32,7 +32,7 @@ class ModelResource extends Resource
 
     public static $model = Model::class;
 
-    protected int $defaultLimit = 32;
+    public int $defaultLimit = 32;
 
     public function createRules(RestRequest $request)
     {

--- a/tests/Support/Rest/Resources/ModelWithDefaultLimitResource.php
+++ b/tests/Support/Rest/Resources/ModelWithDefaultLimitResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lomkit\Rest\Tests\Support\Rest\Resources;
+
+use Lomkit\Rest\Concerns\Resource\DisableGates;
+use Lomkit\Rest\Http\Requests\RestRequest;
+use Lomkit\Rest\Http\Resource;
+use Lomkit\Rest\Relations\BelongsTo;
+use Lomkit\Rest\Relations\BelongsToMany;
+use Lomkit\Rest\Relations\HasMany;
+use Lomkit\Rest\Relations\HasManyThrough;
+use Lomkit\Rest\Relations\HasOne;
+use Lomkit\Rest\Relations\HasOneOfMany;
+use Lomkit\Rest\Relations\HasOneThrough;
+use Lomkit\Rest\Relations\MorphedByMany;
+use Lomkit\Rest\Relations\MorphMany;
+use Lomkit\Rest\Relations\MorphOne;
+use Lomkit\Rest\Relations\MorphOneOfMany;
+use Lomkit\Rest\Relations\MorphTo;
+use Lomkit\Rest\Relations\MorphToMany;
+use Lomkit\Rest\Tests\Support\Models\Model;
+use Lomkit\Rest\Tests\Support\Rest\Actions\BatchableModifyNumberAction;
+use Lomkit\Rest\Tests\Support\Rest\Actions\ModifyNumberAction;
+use Lomkit\Rest\Tests\Support\Rest\Actions\QueueableModifyNumberAction;
+use Lomkit\Rest\Tests\Support\Rest\Actions\StandaloneModifyNumberAction;
+use Lomkit\Rest\Tests\Support\Rest\Actions\WithMetaModifyNumberAction;
+use Lomkit\Rest\Tests\Support\Rest\Instructions\NumberedInstruction;
+
+class ModelWithDefaultLimitResource extends ModelResource
+{
+    public int $defaultLimit = 32;
+}

--- a/tests/Support/Rest/Resources/ModelWithDefaultLimitResource.php
+++ b/tests/Support/Rest/Resources/ModelWithDefaultLimitResource.php
@@ -2,30 +2,6 @@
 
 namespace Lomkit\Rest\Tests\Support\Rest\Resources;
 
-use Lomkit\Rest\Concerns\Resource\DisableGates;
-use Lomkit\Rest\Http\Requests\RestRequest;
-use Lomkit\Rest\Http\Resource;
-use Lomkit\Rest\Relations\BelongsTo;
-use Lomkit\Rest\Relations\BelongsToMany;
-use Lomkit\Rest\Relations\HasMany;
-use Lomkit\Rest\Relations\HasManyThrough;
-use Lomkit\Rest\Relations\HasOne;
-use Lomkit\Rest\Relations\HasOneOfMany;
-use Lomkit\Rest\Relations\HasOneThrough;
-use Lomkit\Rest\Relations\MorphedByMany;
-use Lomkit\Rest\Relations\MorphMany;
-use Lomkit\Rest\Relations\MorphOne;
-use Lomkit\Rest\Relations\MorphOneOfMany;
-use Lomkit\Rest\Relations\MorphTo;
-use Lomkit\Rest\Relations\MorphToMany;
-use Lomkit\Rest\Tests\Support\Models\Model;
-use Lomkit\Rest\Tests\Support\Rest\Actions\BatchableModifyNumberAction;
-use Lomkit\Rest\Tests\Support\Rest\Actions\ModifyNumberAction;
-use Lomkit\Rest\Tests\Support\Rest\Actions\QueueableModifyNumberAction;
-use Lomkit\Rest\Tests\Support\Rest\Actions\StandaloneModifyNumberAction;
-use Lomkit\Rest\Tests\Support\Rest\Actions\WithMetaModifyNumberAction;
-use Lomkit\Rest\Tests\Support\Rest\Instructions\NumberedInstruction;
-
 class ModelWithDefaultLimitResource extends ModelResource
 {
     public int $defaultLimit = 32;

--- a/tests/Support/Routes/api.php
+++ b/tests/Support/Routes/api.php
@@ -7,6 +7,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
     \Lomkit\Rest\Facades\Rest::resource('searchable-models', \Lomkit\Rest\Tests\Support\Http\Controllers\SearchableModelController::class);
     \Lomkit\Rest\Facades\Rest::resource('model-hooks', \Lomkit\Rest\Tests\Support\Http\Controllers\ModelHooksController::class)->withSoftDeletes();
     \Lomkit\Rest\Facades\Rest::resource('model-withs', \Lomkit\Rest\Tests\Support\Http\Controllers\ModelWithController::class);
+    \Lomkit\Rest\Facades\Rest::resource('model-with-default-limit', \Lomkit\Rest\Tests\Support\Http\Controllers\ModelWithDefaultLimitController::class);
     \Lomkit\Rest\Facades\Rest::resource('no-relationship-authorization-models', \Lomkit\Rest\Tests\Support\Http\Controllers\NoRelationshipAuthorizationModelController::class);
 
     \Lomkit\Rest\Facades\Rest::resource('no-exposed-fields', \Lomkit\Rest\Tests\Support\Http\Controllers\NoExposedFieldsController::class);


### PR DESCRIPTION
closes #157 

This PR adds the possibility of defining a default pagnination limit for a specific model.

If not defined, the value remains 50.

I took the opportunity to update the `Resource` models with this new feature.

It will be necessary to update the doc according to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced pagination to use a configurable default limit for displayed items.
  - Introduced a new API endpoint that demonstrates customizable pagination behavior.

- **Tests**
  - Added test cases verifying that resources return the correct default number of items per page in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->