### PR TITLE
Aggregate alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ Here is a quick look at what you can do using API search method:
 
 - Metrics support
 - Refactor the response class
-- Alias for includes / aggregates
+- Alias for includes

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -71,7 +71,7 @@ class Response implements Responsable
                         // Here we add the aggregates
                         collect($currentRequestArray['aggregates'] ?? [])
                             ->map(function ($aggregate) {
-                                return Str::snake($aggregate['relation']).'_'.$aggregate['type'].(isset($aggregate['field']) ? '_'.$aggregate['field'] : '');
+                                return $aggregate['alias'] ?? Str::snake($aggregate['relation']).'_'.$aggregate['type'].(isset($aggregate['field']) ? '_'.$aggregate['field'] : '');
                             })
                             ->toArray()
                     )

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -53,7 +53,7 @@ class Response implements Responsable
      *
      * @return array The structured array representation of the model, including attributes and recursively processed relations.
      */
-    public function modelToResponse(Model $model, Resource $resource, array $requestArray, Relation $relation = null)
+    public function modelToResponse(Model $model, Resource $resource, array $requestArray, ?Relation $relation = null)
     {
         $currentRequestArray = $relation === null ? $requestArray : collect($requestArray['includes'] ?? [])
             ->first(function ($include) use ($relation) {

--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -237,7 +237,13 @@ trait PerformSearch
      */
     public function aggregate($aggregate)
     {
-        return $this->queryBuilder->withAggregate([$aggregate['relation'] => function (Builder $query) use ($aggregate) {
+        $relation = $aggregate['relation'];
+
+        if (isset($aggregate['alias'])) {
+            $relation .= ' as '.$aggregate['alias'];
+        }
+
+        return $this->queryBuilder->withAggregate([$relation => function (Builder $query) use ($aggregate) {
             $resource = $this->resource->relation($aggregate['relation'])?->resource();
 
             $queryBuilder = $this->newQueryBuilder(['resource' => $resource, 'query' => $query]);

--- a/src/Rules/SearchRules.php
+++ b/src/Rules/SearchRules.php
@@ -341,7 +341,7 @@ class SearchRules implements ValidationRule, ValidatorAwareRule
                 'required_if:'.$prefix.'.*.type,min,max,avg,sum',
                 'prohibited_if:'.$prefix.'.*.type,count,exists',
             ],
-            $prefix.'.*.nullable' => [
+            $prefix.'.*.alias' => [
                 'nullable',
                 'string',
             ],

--- a/src/Rules/SearchRules.php
+++ b/src/Rules/SearchRules.php
@@ -341,6 +341,10 @@ class SearchRules implements ValidationRule, ValidatorAwareRule
                 'required_if:'.$prefix.'.*.type,min,max,avg,sum',
                 'prohibited_if:'.$prefix.'.*.type,count,exists',
             ],
+            $prefix.'.*.nullable' => [
+                'nullable',
+                'string',
+            ],
             $prefix.'.*' => [
                 AggregateField::make()
                     ->resource($resource),

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -192,6 +192,52 @@ class SearchAggregatesOperationsTest extends TestCase
         );
     }
 
+    public function test_getting_a_list_of_resources_aggregating_by_min_number_with_alias(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'min',
+                            'field'    => 'number',
+                            'alias'    => 'min_alias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['min_alias' => $matchingModel->belongsToManyRelation()->orderBy('number', 'asc')->first()->number],
+                ['min_alias' => $matchingModel2->belongsToManyRelation()->orderBy('number', 'asc')->first()->number],
+            ]
+        );
+    }
+
     public function test_getting_a_list_of_resources_aggregating_by_max_number(): void
     {
         $matchingModel = ModelFactory::new()
@@ -233,6 +279,52 @@ class SearchAggregatesOperationsTest extends TestCase
             [
                 ['belongs_to_many_relation_max_number' => $matchingModel->belongsToManyRelation()->orderBy('number', 'desc')->first()->number],
                 ['belongs_to_many_relation_max_number' => $matchingModel2->belongsToManyRelation()->orderBy('number', 'desc')->first()->number],
+            ]
+        );
+    }
+
+    public function test_getting_a_list_of_resources_aggregating_by_max_number_with_alias(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'max',
+                            'field'    => 'number',
+                            'alias'    => 'max_alias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['max_alias' => $matchingModel->belongsToManyRelation()->orderBy('number', 'desc')->first()->number],
+                ['max_alias' => $matchingModel2->belongsToManyRelation()->orderBy('number', 'desc')->first()->number],
             ]
         );
     }
@@ -282,6 +374,52 @@ class SearchAggregatesOperationsTest extends TestCase
         );
     }
 
+    public function test_getting_a_list_of_resources_aggregating_by_avg_number_with_alias(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'avg',
+                            'field'    => 'number',
+                            'alias'    => 'avg_alias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['avg_alias' => $matchingModel->belongsToManyRelation()->avg('belongs_to_many_relations.number')],
+                ['avg_alias' => $matchingModel2->belongsToManyRelation()->avg('belongs_to_many_relations.number')],
+            ]
+        );
+    }
+
     public function test_getting_a_list_of_resources_aggregating_by_sum_number(): void
     {
         $matchingModel = ModelFactory::new()
@@ -323,6 +461,52 @@ class SearchAggregatesOperationsTest extends TestCase
             [
                 ['belongs_to_many_relation_sum_number' => $matchingModel->belongsToManyRelation()->sum('belongs_to_many_relations.number')],
                 ['belongs_to_many_relation_sum_number' => $matchingModel2->belongsToManyRelation()->sum('belongs_to_many_relations.number')],
+            ]
+        );
+    }
+
+    public function test_getting_a_list_of_resources_aggregating_by_sum_number_with_alias(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'sum',
+                            'field'    => 'number',
+                            'alias'    => 'sum_alias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['sum_alias' => $matchingModel->belongsToManyRelation()->sum('belongs_to_many_relations.number')],
+                ['sum_alias' => $matchingModel2->belongsToManyRelation()->sum('belongs_to_many_relations.number')],
             ]
         );
     }
@@ -371,6 +555,51 @@ class SearchAggregatesOperationsTest extends TestCase
         );
     }
 
+    public function test_getting_a_list_of_resources_aggregating_by_count_relation_with_alias(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'count',
+                            'alias'     => 'count_alias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['count_alias' => $matchingModel->belongsToManyRelation()->count()],
+                ['count_alias' => $matchingModel2->belongsToManyRelation()->count()],
+            ]
+        );
+    }
+
     public function test_getting_a_list_of_resources_aggregating_by_exists_relation(): void
     {
         $matchingModel = ModelFactory::new()
@@ -407,6 +636,47 @@ class SearchAggregatesOperationsTest extends TestCase
             [
                 ['belongs_to_many_relation_exists' => false],
                 ['belongs_to_many_relation_exists' => true],
+            ]
+        );
+    }
+
+    public function test_getting_a_list_of_resources_aggregating_by_exists_relation_with_alias(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'exists',
+                            'alias'     => 'exists_alias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['exists_alias' => false],
+                ['exists_alias' => true],
             ]
         );
     }

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -208,7 +208,7 @@ class SearchAggregatesOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -299,7 +299,7 @@ class SearchAggregatesOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -390,7 +390,7 @@ class SearchAggregatesOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -481,7 +481,7 @@ class SearchAggregatesOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -571,7 +571,7 @@ class SearchAggregatesOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -652,7 +652,7 @@ class SearchAggregatesOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -581,7 +581,7 @@ class SearchAggregatesOperationsTest extends TestCase
                         [
                             'relation' => 'belongsToManyRelation',
                             'type'     => 'count',
-                            'alias'     => 'count_alias',
+                            'alias'    => 'count_alias',
                         ],
                     ],
                 ],
@@ -662,7 +662,7 @@ class SearchAggregatesOperationsTest extends TestCase
                         [
                             'relation' => 'belongsToManyRelation',
                             'type'     => 'exists',
-                            'alias'     => 'exists_alias',
+                            'alias'    => 'exists_alias',
                         ],
                     ],
                 ],


### PR DESCRIPTION
Closes : https://github.com/Lomkit/laravel-rest-api/issues/160

This PR adds the possibility of customizing the alias for aggregate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced aggregate operations now support aliasing, allowing flexible naming in search results.
	- Improved validation now accepts nullable aggregate field inputs for greater input flexibility.

- **Tests**
	- Added comprehensive tests covering various aggregate operations (min, max, average, sum, count, and existence) with alias support to ensure consistent behavior.
	- New tests validate aggregation functionality using aliases for specified operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->