### PR TITLE
Change gate for attach mutation

### DIFF
--- a/src/Query/Traits/PerformMutation.php
+++ b/src/Query/Traits/PerformMutation.php
@@ -64,7 +64,7 @@ trait PerformMutation
         } elseif ($mutation['operation'] === 'update') {
             $this->resource->authorizeTo('update', $model);
         } else {
-            if (!$this->resource->authorizeTo('attach' . $model, $model)) {
+            if (!$this->resource->authorizeTo('attach'.$model, $model)) {
                 $this->resource->authorizeTo('view', $model);
             }
         }

--- a/src/Query/Traits/PerformMutation.php
+++ b/src/Query/Traits/PerformMutation.php
@@ -42,7 +42,7 @@ trait PerformMutation
     /**
      * Apply a mutation to the model based on the provided mutation parameters.
      *
-     * @param array $mutation An array of mutation parameters.
+     * @param array $mutation   An array of mutation parameters.
      * @param array $attributes Additional attributes to apply to the model.
      *
      * @return Model The mutated model.

--- a/src/Query/Traits/PerformMutation.php
+++ b/src/Query/Traits/PerformMutation.php
@@ -33,9 +33,7 @@ trait PerformMutation
         ];
 
         foreach ($parameters['mutate'] as $parameter) {
-            $operations[
-                $this->mutateOperationsVerbose[$parameter['operation']]
-            ][] = $this->applyMutation($parameter)->getKey();
+            $operations[$this->mutateOperationsVerbose[$parameter['operation']]][] = $this->applyMutation($parameter)->getKey();
         }
 
         return $operations;
@@ -44,7 +42,7 @@ trait PerformMutation
     /**
      * Apply a mutation to the model based on the provided mutation parameters.
      *
-     * @param array $mutation   An array of mutation parameters.
+     * @param array $mutation An array of mutation parameters.
      * @param array $attributes Additional attributes to apply to the model.
      *
      * @return Model The mutated model.
@@ -64,8 +62,10 @@ trait PerformMutation
         } elseif ($mutation['operation'] === 'update') {
             $this->resource->authorizeTo('update', $model);
         } else {
-            if (!$this->resource->authorizeTo('attach'.$model, $model)) {
+            if (!$this->resource->authorizedTo('attach' . $model, $model)) {
                 $this->resource->authorizeTo('view', $model);
+            } else {
+                $this->resource->authorizeTo('attach' . $model, $model);
             }
         }
 
@@ -79,9 +79,9 @@ trait PerformMutation
     /**
      * Mutate the model by applying attributes and relations.
      *
-     * @param Model $model      The Eloquent model to mutate.
+     * @param Model $model The Eloquent model to mutate.
      * @param array $attributes The attributes to mutate.
-     * @param array $mutation   The mutation array.
+     * @param array $mutation The mutation array.
      *
      * @return Model The mutated model.
      */

--- a/src/Query/Traits/PerformMutation.php
+++ b/src/Query/Traits/PerformMutation.php
@@ -64,7 +64,9 @@ trait PerformMutation
         } elseif ($mutation['operation'] === 'update') {
             $this->resource->authorizeTo('update', $model);
         } else {
-            $this->resource->authorizeTo('view', $model);
+            if (!$this->resource->authorizeTo('attach' . $model, $model)) {
+                $this->resource->authorizeTo('view', $model);
+            }
         }
 
         return $this->mutateModel(

--- a/src/Query/Traits/PerformMutation.php
+++ b/src/Query/Traits/PerformMutation.php
@@ -62,10 +62,10 @@ trait PerformMutation
         } elseif ($mutation['operation'] === 'update') {
             $this->resource->authorizeTo('update', $model);
         } else {
-            if (!$this->resource->authorizedTo('attach' . $model, $model)) {
+            if (!$this->resource->authorizedTo('attach'.$model, $model)) {
                 $this->resource->authorizeTo('view', $model);
             } else {
-                $this->resource->authorizeTo('attach' . $model, $model);
+                $this->resource->authorizeTo('attach'.$model, $model);
             }
         }
 
@@ -79,9 +79,9 @@ trait PerformMutation
     /**
      * Mutate the model by applying attributes and relations.
      *
-     * @param Model $model The Eloquent model to mutate.
+     * @param Model $model      The Eloquent model to mutate.
      * @param array $attributes The attributes to mutate.
-     * @param array $mutation The mutation array.
+     * @param array $mutation   The mutation array.
      *
      * @return Model The mutated model.
      */

--- a/src/Query/Traits/PerformMutation.php
+++ b/src/Query/Traits/PerformMutation.php
@@ -5,6 +5,7 @@ namespace Lomkit\Rest\Query\Traits;
 use Illuminate\Database\Eloquent\Model;
 use Lomkit\Rest\Http\Requests\MutateRequest;
 use Lomkit\Rest\Http\Requests\RestRequest;
+use ReflectionClass;
 
 trait PerformMutation
 {
@@ -62,10 +63,11 @@ trait PerformMutation
         } elseif ($mutation['operation'] === 'update') {
             $this->resource->authorizeTo('update', $model);
         } else {
-            if (!$this->resource->authorizedTo('attach'.$model, $model)) {
+            $attachModel = (new ReflectionClass($model))->getShortName();
+            if (!$this->resource->authorizedTo('attach'.$attachModel, $model)) {
                 $this->resource->authorizeTo('view', $model);
             } else {
-                $this->resource->authorizeTo('attach'.$model, $model);
+                $this->resource->authorizeTo('attach'.$attachModel, $model);
             }
         }
 

--- a/tests/Feature/Controllers/AutomaticGatingTest.php
+++ b/tests/Feature/Controllers/AutomaticGatingTest.php
@@ -335,7 +335,7 @@ class AutomaticGatingTest extends TestCase
                         'authorized_to_update'       => true,
                         'authorized_to_delete'       => true,
                         'authorized_to_restore'      => true,
-                        'authorized_to_force_delete' => true,
+                        'authorized_to_force_delete' => true
                     ],
                     'belongs_to_many_relation' => $matchingModel->belongsToManyRelation()
                         ->orderBy('id', 'desc')

--- a/tests/Feature/Controllers/AutomaticGatingTest.php
+++ b/tests/Feature/Controllers/AutomaticGatingTest.php
@@ -335,7 +335,7 @@ class AutomaticGatingTest extends TestCase
                         'authorized_to_update'       => true,
                         'authorized_to_delete'       => true,
                         'authorized_to_restore'      => true,
-                        'authorized_to_force_delete' => true
+                        'authorized_to_force_delete' => true,
                     ],
                     'belongs_to_many_relation' => $matchingModel->belongsToManyRelation()
                         ->orderBy('id', 'desc')

--- a/tests/Feature/Controllers/AutomaticGatingTest.php
+++ b/tests/Feature/Controllers/AutomaticGatingTest.php
@@ -48,7 +48,7 @@ class AutomaticGatingTest extends TestCase
             [
                 [
                     'gates' => [
-                        'authorized_to_view'         => true,
+                        'authorized_to_view'         => false,
                         'authorized_to_update'       => true,
                         'authorized_to_delete'       => true,
                         'authorized_to_restore'      => true,
@@ -331,11 +331,11 @@ class AutomaticGatingTest extends TestCase
             [
                 [
                     'gates' => [
-                        'authorized_to_view'         => true,
+                        'authorized_to_view'         => false,
                         'authorized_to_update'       => true,
                         'authorized_to_delete'       => true,
                         'authorized_to_restore'      => true,
-                        'authorized_to_force_delete' => true,
+                        'authorized_to_force_delete' => true
                     ],
                     'belongs_to_many_relation' => $matchingModel->belongsToManyRelation()
                         ->orderBy('id', 'desc')
@@ -357,7 +357,7 @@ class AutomaticGatingTest extends TestCase
                 ],
                 [
                     'gates' => [
-                        'authorized_to_view'         => true,
+                        'authorized_to_view'         => false,
                         'authorized_to_update'       => true,
                         'authorized_to_delete'       => true,
                         'authorized_to_restore'      => true,

--- a/tests/Support/Policies/GreenPolicy.php
+++ b/tests/Support/Policies/GreenPolicy.php
@@ -31,7 +31,7 @@ class GreenPolicy
      */
     public function view($user, Model $model)
     {
-        return true;
+        return false;
     }
 
     /**
@@ -94,6 +94,119 @@ class GreenPolicy
      * @return bool
      */
     public function forceDelete($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachBelongsToRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachHasOneRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachHasOneOfManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachBelongsToManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachHasManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachBelongsToRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachHasOneRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachHasOneOfManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachBelongsToManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachHasManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    /**
+     * MORPHS.
+     */
+    public function attachMorphToRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachMorphOneRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachMorphOneOfManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachMorphToManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachMorphManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function attachMorphedByManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachMorphToRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachMorphOneRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachMorphOneOfManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachMorphToManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachMorphManyRelation($user, Model $model)
+    {
+        return true;
+    }
+
+    public function detachMorphedByManyRelation($user, Model $model)
     {
         return true;
     }


### PR DESCRIPTION
close #162 

I've added the possibility of using the `attachModel` gate when attaching to the `PerformMutate`, as indicated in the documentation.

I've left the possibility of using `view` so as not to create a breaking change. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization checks for certain mutation operations, ensuring more specific permissions are verified before falling back to general permissions.
  - Updated policy rules to better control access for attaching and detaching various relationship types, enhancing security and permission granularity.
  - Adjusted expected view permissions in tests to reflect updated authorization logic, improving accuracy of access control validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->