### PR TITLE
Add HandlePrecognitiveRequests middleware for frontend rules validation

### DIFF
--- a/config/rest.php
+++ b/config/rest.php
@@ -45,6 +45,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Precognition Support
+    |--------------------------------------------------------------------------
+    |
+    | This option enables support for Laravel Precognition, which allows
+    | frontend applications to perform validation requests without executing
+    | controller logic. When enabled, requests containing the "Precognition"
+    | header will only trigger middleware and validation, skipping the actual
+    | controller method. This is especially useful for live form validation.
+    |
+    */
+
+    'precognition' => [
+        'enabled' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Rest Documentation
     |--------------------------------------------------------------------------
     |

--- a/src/Rest.php
+++ b/src/Rest.php
@@ -36,7 +36,8 @@ class Rest implements Registrar
             $controller,
             $options
         ))
-            ->middleware(EnforceExpectsJson::class);
+            ->middleware(EnforceExpectsJson::class)
+            ->middleware(HandlePrecognitiveRequests::class);
     }
 
     /**

--- a/src/Rest.php
+++ b/src/Rest.php
@@ -2,6 +2,7 @@
 
 namespace Lomkit\Rest;
 
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use Lomkit\Rest\Contracts\Http\Routing\Registrar;
 use Lomkit\Rest\Documentation\Schemas\OpenAPI;
 use Lomkit\Rest\Http\Controllers\Controller;
@@ -30,14 +31,20 @@ class Rest implements Registrar
             $registrar = new ResourceRegistrar(app('router'));
         }
 
-        return (new PendingResourceRegistration(
+        $pendingResourceRegistration = (new PendingResourceRegistration(
             $registrar,
             $name,
             $controller,
             $options
         ))
-            ->middleware(EnforceExpectsJson::class)
-            ->middleware(HandlePrecognitiveRequests::class);
+            ->middleware(EnforceExpectsJson::class);
+
+        return tap($pendingResourceRegistration, function ($pendingResourceRegistration) {
+            if (config('rest.precognition.enabled', false)) {
+                $pendingResourceRegistration
+                    ->middleware(HandlePrecognitiveRequests::class);
+            }
+        });
     }
 
     /**

--- a/tests/Feature/Controllers/PrecognitionOperationsTest.php
+++ b/tests/Feature/Controllers/PrecognitionOperationsTest.php
@@ -23,7 +23,7 @@ class PrecognitionOperationsTest extends TestCase
         ModelFactory::new()->count(2)->create();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -53,7 +53,7 @@ class PrecognitionOperationsTest extends TestCase
         ModelFactory::new()->count(2)->create();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -94,7 +94,7 @@ class PrecognitionOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',
@@ -134,7 +134,7 @@ class PrecognitionOperationsTest extends TestCase
             ->create()->fresh();
 
         Gate::policy(Model::class, GreenPolicy::class);
-        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
 
         $response = $this->post(
             '/api/models/search',

--- a/tests/Feature/Controllers/PrecognitionOperationsTest.php
+++ b/tests/Feature/Controllers/PrecognitionOperationsTest.php
@@ -2,7 +2,6 @@
 
 namespace Controllers;
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Gate;
 use Lomkit\Rest\Tests\Feature\TestCase;
 use Lomkit\Rest\Tests\Support\Database\Factories\BelongsToManyRelationFactory;
@@ -41,7 +40,7 @@ class PrecognitionOperationsTest extends TestCase
             ],
             [
                 'Precognition' => 'true',
-                'Accept' => 'application/json'
+                'Accept'       => 'application/json'
             ]
         );
 
@@ -70,7 +69,7 @@ class PrecognitionOperationsTest extends TestCase
                 ],
             ],
             [
-                'Accept' => 'application/json',
+                'Accept'       => 'application/json',
                 'Precognition' => 'fields=aggregates.0.relation,aggregates.0.type',
             ]
         );
@@ -111,7 +110,7 @@ class PrecognitionOperationsTest extends TestCase
                 ],
             ],
             [
-                'Accept' => 'application/json',
+                'Accept'       => 'application/json',
                 'Precognition' => 'true',
             ]
         );

--- a/tests/Feature/Controllers/PrecognitionOperationsTest.php
+++ b/tests/Feature/Controllers/PrecognitionOperationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Controllers;
+namespace Lomkit\Rest\Tests\Feature\Controllers;
 
 use Illuminate\Support\Facades\Gate;
 use Lomkit\Rest\Tests\Feature\TestCase;

--- a/tests/Feature/Controllers/PrecognitionOperationsTest.php
+++ b/tests/Feature/Controllers/PrecognitionOperationsTest.php
@@ -40,7 +40,7 @@ class PrecognitionOperationsTest extends TestCase
             ],
             [
                 'Precognition' => 'true',
-                'Accept'       => 'application/json'
+                'Accept'       => 'application/json',
             ]
         );
 

--- a/tests/Feature/Controllers/PrecognitionOperationsTest.php
+++ b/tests/Feature/Controllers/PrecognitionOperationsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Controllers;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
+use Lomkit\Rest\Tests\Feature\TestCase;
+use Lomkit\Rest\Tests\Support\Database\Factories\BelongsToManyRelationFactory;
+use Lomkit\Rest\Tests\Support\Database\Factories\ModelFactory;
+use Lomkit\Rest\Tests\Support\Models\BelongsToManyRelation;
+use Lomkit\Rest\Tests\Support\Models\Model;
+use Lomkit\Rest\Tests\Support\Policies\GreenPolicy;
+use Lomkit\Rest\Tests\Support\Rest\Resources\ModelResource;
+
+class PrecognitionOperationsTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('rest.precognition.enabled', true);
+    }
+
+    public function test_precognition_getting_a_list_of_resources_aggregating_by_unauthorized_relation(): void
+    {
+        ModelFactory::new()->count(2)->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'unauthorized_relation',
+                            'type'     => 'min',
+                            'field'    => 'id',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Precognition' => 'true',
+                'Accept' => 'application/json'
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.aggregates.0.relation']]);
+    }
+
+    public function test_getting_a_list_of_resources_aggregating_by_specifying_field_when_not_necessary(): void
+    {
+        ModelFactory::new()->count(2)->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'exists',
+                            'field'    => 'id',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Accept' => 'application/json',
+                'Precognition' => 'fields=aggregates.0.relation,aggregates.0.type',
+            ]
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.aggregates.0.field']]);
+    }
+
+    public function test_precognition_getting_a_list_of_resources_aggregating_by_min_number(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'min',
+                            'field'    => 'number',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Accept' => 'application/json',
+                'Precognition' => 'true',
+            ]
+        );
+
+        $response->assertNoContent();
+    }
+
+    public function test_precognition_getting_a_list_of_resources_aggregating_by_min_number_without_precognition(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+        $matchingModel2 = ModelFactory::new()
+            ->has(
+                BelongsToManyRelationFactory::new()
+                    ->count(20)
+            )
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(belongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'aggregates' => [
+                        [
+                            'relation' => 'belongsToManyRelation',
+                            'type'     => 'min',
+                            'field'    => 'number',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Accept' => 'application/json',
+            ]
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                ['belongs_to_many_relation_min_number' => $matchingModel->belongsToManyRelation()->orderBy('number', 'asc')->first()->number],
+                ['belongs_to_many_relation_min_number' => $matchingModel2->belongsToManyRelation()->orderBy('number', 'asc')->first()->number],
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Adds the HandlePrecognitiveRequests middleware to Lomkit Rest resources.

- Enables frontend validation with Laravel Precognition without modifying the database or executing business logic.
- To trigger this middleware, simply add Precognition: true to your request headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional support for Laravel Precognition to enable frontend live validation without executing full controller logic.
  * Introduced configuration option to enable or disable Precognition support for resource requests.

* **Bug Fixes**
  * Improved validation and authorization handling for resource aggregation operations with Precognition requests.

* **Tests**
  * Added tests to verify behavior of resource aggregation with and without Precognition enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->