### PR TITLE
🐛 search text with null operator

### DIFF
--- a/src/Rules/Search/SearchText.php
+++ b/src/Rules/Search/SearchText.php
@@ -16,7 +16,7 @@ class SearchText extends RestRule
 
         return [
             $attribute          => ['sometimes', 'array'],
-            $attribute.'.value' => ['string'],
+            $attribute.'.value' => ['nullable', 'string'],
         ];
     }
 }

--- a/tests/Feature/Controllers/SearchScoutOperationsTest.php
+++ b/tests/Feature/Controllers/SearchScoutOperationsTest.php
@@ -329,4 +329,54 @@ class SearchScoutOperationsTest extends TestCase
             new ModelResource()
         );
     }
+
+    public function test_getting_a_list_of_resources_with_empty_scout(): void
+    {
+        ModelFactory::new()->count(2)->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/searchable-models/search',
+            [
+                'search' => [
+                    'text' => [
+                        'value' => '',
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [],
+            new ModelResource()
+        );
+    }
+
+    public function test_getting_a_list_of_resources_with_null_scout(): void
+    {
+        ModelFactory::new()->count(2)->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/searchable-models/search',
+            [
+                'search' => [
+                    'text' => [
+                        'value' => null,
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [],
+            new ModelResource()
+        );
+    }
 }


### PR DESCRIPTION
closes #182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search functionality to allow the search text field to be left empty or set to null without causing errors.

* **Tests**
  * Added tests to ensure the search endpoint works correctly when the search text is empty or null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->