### PR TITLE
:bug: destructive operations gates

### DIFF
--- a/src/Concerns/PerformsRestOperations.php
+++ b/src/Concerns/PerformsRestOperations.php
@@ -140,7 +140,9 @@ trait PerformsRestOperations
 
         foreach ($models as $model) {
             self::newResource()->authorizeTo('delete', $model);
+        }
 
+        foreach ($models as $model) {
             $resource->destroying($request, $model);
 
             $resource->performDelete($request, $model);
@@ -177,7 +179,9 @@ trait PerformsRestOperations
 
         foreach ($models as $model) {
             self::newResource()->authorizeTo('restore', $model);
+        }
 
+        foreach ($models as $model) {
             $resource->restoring($request, $model);
 
             $resource->performRestore($request, $model);
@@ -215,7 +219,9 @@ trait PerformsRestOperations
 
         foreach ($models as $model) {
             self::newResource()->authorizeTo('forceDelete', $model);
+        }
 
+        foreach ($models as $model) {
             $resource->forceDestroying($request, $model);
 
             $resource->performForceDelete($request, $model);

--- a/tests/Feature/Controllers/RestoreOperationsTest.php
+++ b/tests/Feature/Controllers/RestoreOperationsTest.php
@@ -4,10 +4,13 @@ namespace Lomkit\Rest\Tests\Feature\Controllers;
 
 use Illuminate\Support\Facades\Gate;
 use Lomkit\Rest\Tests\Feature\TestCase;
+use Lomkit\Rest\Tests\Support\Database\Factories\ModelFactory;
 use Lomkit\Rest\Tests\Support\Database\Factories\SoftDeletedModelFactory;
+use Lomkit\Rest\Tests\Support\Models\Model;
 use Lomkit\Rest\Tests\Support\Models\SoftDeletedModel;
 use Lomkit\Rest\Tests\Support\Policies\GreenPolicy;
 use Lomkit\Rest\Tests\Support\Policies\RedPolicy;
+use Lomkit\Rest\Tests\Support\Policies\RedPolicyButForModel;
 use Lomkit\Rest\Tests\Support\Rest\Resources\SoftDeletedModelResource;
 
 class RestoreOperationsTest extends TestCase
@@ -28,6 +31,34 @@ class RestoreOperationsTest extends TestCase
 
         $response->assertStatus(403);
         $response->assertJson(['message' => 'This action is unauthorized.']);
+    }
+
+    public function test_restoring_a_non_authorized_model_with_an_authorized_one(): void
+    {
+        $model = SoftDeletedModelFactory::new()->count(1)->trashed()->createOne();
+        $modelRestorable = SoftDeletedModelFactory::new()->count(1)->trashed()->createOne();
+
+        RedPolicyButForModel::forModel($modelRestorable);
+        Gate::policy(SoftDeletedModel::class, RedPolicyButForModel::class);
+
+        $response = $this->post(
+            '/api/soft-deleted-models/restore',
+            [
+                'resources' => [$model->getKey(), $modelRestorable->getKey()],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(403);
+        $response->assertJson(['message' => 'This action is unauthorized.']);
+        $this->assertNotEquals(
+            null,
+            $modelRestorable->fresh()->deleted_at,
+        );
+        $this->assertNotEquals(
+            null,
+            $model->fresh()->deleted_at,
+        );
     }
 
     public function test_restoring_a_soft_deleted_model(): void

--- a/tests/Feature/Controllers/RestoreOperationsTest.php
+++ b/tests/Feature/Controllers/RestoreOperationsTest.php
@@ -4,9 +4,7 @@ namespace Lomkit\Rest\Tests\Feature\Controllers;
 
 use Illuminate\Support\Facades\Gate;
 use Lomkit\Rest\Tests\Feature\TestCase;
-use Lomkit\Rest\Tests\Support\Database\Factories\ModelFactory;
 use Lomkit\Rest\Tests\Support\Database\Factories\SoftDeletedModelFactory;
-use Lomkit\Rest\Tests\Support\Models\Model;
 use Lomkit\Rest\Tests\Support\Models\SoftDeletedModel;
 use Lomkit\Rest\Tests\Support\Policies\GreenPolicy;
 use Lomkit\Rest\Tests\Support\Policies\RedPolicy;

--- a/tests/Support/Policies/RedPolicyButForModel.php
+++ b/tests/Support/Policies/RedPolicyButForModel.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Lomkit\Rest\Tests\Support\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Database\Eloquent\Model;
+
+class RedPolicyButForModel
+{
+    use HandlesAuthorization;
+
+    static Model $model;
+
+    public static function forModel(Model $model) {
+        static::$model = $model;
+    }
+
+    /**
+     * Determine whether the user can view the list of models.
+     *
+     * @param $user
+     *
+     * @return bool
+     */
+    public function viewAny($user)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param       $user
+     * @param Model $model
+     *
+     * @return bool
+     */
+    public function view($user, Model $model)
+    {
+        return static::$model->is($model);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param $user
+     *
+     * @return bool
+     */
+    public function create($user)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param       $user
+     * @param Model $model
+     *
+     * @return bool
+     */
+    public function update($user, Model $model)
+    {
+        return static::$model->is($model);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param       $user
+     * @param Model $model
+     *
+     * @return bool
+     */
+    public function delete($user, Model $model)
+    {
+        return static::$model->is($model);
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param       $user
+     * @param Model $model
+     *
+     * @return bool
+     */
+    public function restore($user, Model $model)
+    {
+        return static::$model->is($model);
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param       $user
+     * @param Model $model
+     *
+     * @return bool
+     */
+    public function forceDelete($user, Model $model)
+    {
+        return static::$model->is($model);
+    }
+}

--- a/tests/Support/Policies/RedPolicyButForModel.php
+++ b/tests/Support/Policies/RedPolicyButForModel.php
@@ -9,9 +9,10 @@ class RedPolicyButForModel
 {
     use HandlesAuthorization;
 
-    static Model $model;
+    public static Model $model;
 
-    public static function forModel(Model $model) {
+    public static function forModel(Model $model)
+    {
         static::$model = $model;
     }
 


### PR DESCRIPTION
closes #181 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify that batch operations (delete, restore, force delete) fail if any model in the batch is unauthorized, ensuring no changes are made when authorization is denied.
  * Introduced a custom policy for fine-grained authorization in tests.

* **Refactor**
  * Improved the handling of batch operations by separating authorization checks from mutation actions for more consistent and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->