### PR TITLE
🐛 include in include

### DIFF
--- a/src/Rules/Search/SearchInclude.php
+++ b/src/Rules/Search/SearchInclude.php
@@ -25,9 +25,6 @@ class SearchInclude extends RestRule
                     'required',
                     (new ResourceRelationOrNested())->setResource($this->resource),
                 ],
-                $attribute.'.includes' => [
-                    'prohibited',
-                ],
                 $attribute.'.text' => [
                     'prohibited',
                 ],

--- a/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
+++ b/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
@@ -310,8 +310,8 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
                         [
                             'relation' => 'belongsToRelation',
                             'includes' => [
-                                ['relation' => 'models']
-                            ]
+                                ['relation' => 'models'],
+                            ],
                         ],
                     ],
                 ],

--- a/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
+++ b/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
@@ -290,6 +290,62 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
         );
     }
 
+    public function test_getting_a_list_of_resources_including_belongs_to_has_many_relation_using_nested_include(): void
+    {
+        $belongsTo = BelongsToRelationFactory::new()->create();
+        $matchingModel = ModelFactory::new()
+            ->for($belongsTo)
+            ->create()->fresh();
+
+        $matchingModel2 = ModelFactory::new()->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        [
+                            'relation' => 'belongsToRelation',
+                            'includes' => [
+                                ['relation' => 'models']
+                            ]
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $matchingModelBelongsToRelation = $matchingModel->belongsToRelation;
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                [
+                    'belongs_to_relation' => array_merge(
+                        $matchingModelBelongsToRelation
+                            ->only((new BelongsToResource())->getFields(app()->make(RestRequest::class))),
+                        [
+                            'models' => $matchingModelBelongsToRelation->models
+                                ->map(function ($model) {
+                                    return $model->only((new ModelResource())->getFields(app()->make(RestRequest::class)));
+                                })
+                                ->toArray(),
+                        ]
+                    ),
+                ],
+                [
+                    'belongs_to_relation' => null,
+                ],
+            ]
+        );
+    }
+
     public function test_getting_a_list_of_resources_including_distant_relation_with_intermediary_search_query_condition(): void
     {
         $matchingModel = ModelFactory::new()->create(


### PR DESCRIPTION
closes #189 
closes #175 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nested relationship includes in search now allowed: include a relation and its nested related records (e.g., parent relation plus its child collection) in one search request.
* **Changes**
  * Validation updated so nested include sub-fields are no longer explicitly blocked by this validator, allowing legitimate nested include requests to proceed (other validations may still apply).
* **Tests**
  * Added tests covering nested includes for belongs-to → has-many and validation error handling for unauthorized nested includes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->