### PR TITLE
Fix/delete unexisting resource

### DIFF
--- a/src/Http/Requests/DestroyRequest.php
+++ b/src/Http/Requests/DestroyRequest.php
@@ -23,7 +23,7 @@ class DestroyRequest extends RestRequest
     /**
      * Define the validation rules for destroying resources.
      *
-     * @param resource $resource
+     * @param Resource $resource
      *
      * @return array
      *
@@ -40,6 +40,7 @@ class DestroyRequest extends RestRequest
                 'required', 'array',
             ],
             'resources.*' => [
+                'distinct',
                 Rule::exists($model->getTable(), $model->getKeyName()),
             ],
         ];

--- a/src/Http/Requests/DestroyRequest.php
+++ b/src/Http/Requests/DestroyRequest.php
@@ -23,7 +23,7 @@ class DestroyRequest extends RestRequest
     /**
      * Define the validation rules for destroying resources.
      *
-     * @param Resource $resource
+     * @param resource $resource
      *
      * @return array
      *

--- a/src/Http/Requests/DestroyRequest.php
+++ b/src/Http/Requests/DestroyRequest.php
@@ -2,6 +2,7 @@
 
 namespace Lomkit\Rest\Http\Requests;
 
+use Illuminate\Validation\Rule;
 use Lomkit\Rest\Http\Resource;
 
 class DestroyRequest extends RestRequest
@@ -32,10 +33,15 @@ class DestroyRequest extends RestRequest
      */
     public function destroyRules(Resource $resource)
     {
+        $model = $resource::newModel();
+
         return [
             'resources' => [
                 'required', 'array',
             ],
+            'resources.*' => [
+                Rule::exists($model->getTable(), $model->getKeyName())
+            ]
         ];
     }
 }

--- a/tests/Feature/Controllers/DeleteOperationsTest.php
+++ b/tests/Feature/Controllers/DeleteOperationsTest.php
@@ -66,7 +66,7 @@ class DeleteOperationsTest extends TestCase
             '/api/models',
             [
                 'resources' => [
-                    'undefined-id',
+                    999999,
                     $model->getKey()
                 ],
             ],

--- a/tests/Feature/Controllers/DeleteOperationsTest.php
+++ b/tests/Feature/Controllers/DeleteOperationsTest.php
@@ -56,6 +56,28 @@ class DeleteOperationsTest extends TestCase
         $this->assertDatabaseHas('models', $modelDeletable->only('id'));
     }
 
+    public function test_deleting_a_not_existing_model(): void
+    {
+        $model = ModelFactory::new()->count(1)->createOne();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+
+        $response = $this->delete(
+            '/api/models',
+            [
+                'resources' => [
+                    'undefined-id',
+                    $model->getKey()
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['resources.0']]);
+        $this->assertDatabaseHas('models', $model->only('id'));
+    }
+
     public function test_deleting_a_model(): void
     {
         $model = ModelFactory::new()->count(1)->createOne();

--- a/tests/Feature/Controllers/DeleteOperationsTest.php
+++ b/tests/Feature/Controllers/DeleteOperationsTest.php
@@ -56,7 +56,7 @@ class DeleteOperationsTest extends TestCase
         $this->assertDatabaseHas('models', $modelDeletable->only('id'));
     }
 
-    public function test_deleting_a_not_existing_model(): void
+    public function test_deleting_a_non_existing_model(): void
     {
         $model = ModelFactory::new()->count(1)->createOne();
 


### PR DESCRIPTION
closes #178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bulk delete now validates each requested item exists, preventing any partial deletions.
  - Returns a clear 422 validation error with item-specific feedback when any provided ID is invalid.

- **Tests**
  - Added tests to confirm 422 responses and that no deletions occur when a non-existent ID is included in bulk delete requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->