### PR TITLE
Support empty mutate keys

### DIFF
--- a/src/Rules/Mutate/Mutate.php
+++ b/src/Rules/Mutate/Mutate.php
@@ -42,11 +42,6 @@ class Mutate extends RestRule
                 ],
                 $attributeConsideringRelationType.'.key' => [
                     'sometimes',
-                    'required_if:'.$attributeConsideringRelationType.'.operation,update',
-                    'required_if:'.$attributeConsideringRelationType.'.operation,attach',
-                    'required_if:'.$attributeConsideringRelationType.'.operation,detach',
-                    'required_if:'.$attributeConsideringRelationType.'.operation,toggle',
-                    'required_if:'.$attributeConsideringRelationType.'.operation,sync',
                     'prohibited_if:'.$attributeConsideringRelationType.'.operation,create',
                     'exists:'.$this->resource::newModel()->getTable().','.$this->resource::newModel()->getKeyName(),
                 ],

--- a/src/Rules/Mutate/Mutate.php
+++ b/src/Rules/Mutate/Mutate.php
@@ -22,7 +22,7 @@ class Mutate extends RestRule
 
         $operationRules = Rule::in('create', 'update', ...($this->depth === 0 ? [] : ['attach', 'detach', 'toggle', 'sync']));
 
-        $attributeConsideringRelationType = $attribute . ($this->relation?->hasMultipleEntries() ? '.*' : '');
+        $attributeConsideringRelationType = $attribute.($this->relation?->hasMultipleEntries() ? '.*' : '');
 
         return array_merge(
             [
@@ -30,60 +30,42 @@ class Mutate extends RestRule
                     (new ResourceMutateRelationOperation())->setResource($this->resource),
                     (new ResourceCustomRules())->setResource($this->resource),
                 ],
-
-                $attributeConsideringRelationType . '.operation' => [
+                $attributeConsideringRelationType.'.operation' => [
                     'required',
                     $operationRules,
                 ],
-
-                $attributeConsideringRelationType . '.attributes' => [
+                $attributeConsideringRelationType.'.attributes' => [
                     'array',
-                    'prohibited_if:' . $attributeConsideringRelationType . '.operation,attach',
-                    'prohibited_if:' . $attributeConsideringRelationType . '.operation,detach',
-
-                    Rule::when(function () use ($request, $attributeConsideringRelationType) {
-                        $val = data_get($request->all(), $attributeConsideringRelationType . '.attributes');
-                        return is_array($val) && !empty($val);
-                    }, [
-                        new ArrayWithKey($this->resource->getFields($request)),
-                    ]),
+                    'prohibited_if:'.$attributeConsideringRelationType.'.operation,attach',
+                    'prohibited_if:'.$attributeConsideringRelationType.'.operation,detach',
+                    new ArrayWithKey($this->resource->getFields($request)),
                 ],
-
-                $attributeConsideringRelationType . '.key' => [
-                    'required_if:' . $attributeConsideringRelationType . '.operation,update',
-                    'required_if:' . $attributeConsideringRelationType . '.operation,attach',
-                    'required_if:' . $attributeConsideringRelationType . '.operation,detach',
-                    'required_if:' . $attributeConsideringRelationType . '.operation,toggle',
-                    'required_if:' . $attributeConsideringRelationType . '.operation,sync',
-                    'prohibited_if:' . $attributeConsideringRelationType . '.operation,create',
-                    'exists:' . $this->resource::newModel()->getTable() . ',' . $this->resource::newModel()->getKeyName(),
+                $attributeConsideringRelationType.'.key' => [
+                    'sometimes',
+                    'required_if:'.$attributeConsideringRelationType.'.operation,update',
+                    'required_if:'.$attributeConsideringRelationType.'.operation,attach',
+                    'required_if:'.$attributeConsideringRelationType.'.operation,detach',
+                    'required_if:'.$attributeConsideringRelationType.'.operation,toggle',
+                    'required_if:'.$attributeConsideringRelationType.'.operation,sync',
+                    'prohibited_if:'.$attributeConsideringRelationType.'.operation,create',
+                    'exists:'.$this->resource::newModel()->getTable().','.$this->resource::newModel()->getKeyName(),
                 ],
-
-                $attributeConsideringRelationType . '.without_detaching' => [
+                $attributeConsideringRelationType.'.without_detaching' => [
                     'boolean',
-                    'prohibited_unless:' . $attributeConsideringRelationType . '.operation,sync',
+                    'prohibited_unless:'.$attributeConsideringRelationType.'.operation,sync',
                 ],
-
-                $attributeConsideringRelationType . '.relations' => [
+                $attributeConsideringRelationType.'.relations' => [
                     'sometimes',
                     'array',
-
-                    Rule::when(function () use ($request, $attributeConsideringRelationType) {
-                        $val = data_get($request->all(), $attributeConsideringRelationType . '.relations');
-                        return is_array($val) && !empty($val);
-                    }, [
-                        new ArrayWithKey(
-                            collect($this->resource->getRelations($request))
-                                ->map(function (Relation $relation) {
-                                    return $relation->relation;
-                                })
-                                ->toArray()
-                        ),
-                    ]),
+                    new ArrayWithKey(
+                        collect($this->resource->getRelations($request))
+                            ->map(function (Relation $relation) {
+                                return $relation->relation;
+                            })
+                            ->toArray()
+                    ),
                 ],
-
-                $attributeConsideringRelationType . '.relations.*' =>
-                    (new MutateRelation(depth: $this->depth))->setResource($this->resource),
+                $attributeConsideringRelationType.'.relations.*' => (new MutateRelation(depth: $this->depth))->setResource($this->resource),
             ],
             $this->relation?->rules($this->resource, $attribute) ?? []
         );

--- a/src/Rules/Mutate/Mutate.php
+++ b/src/Rules/Mutate/Mutate.php
@@ -42,6 +42,7 @@ class Mutate extends RestRule
                 ],
                 $attributeConsideringRelationType.'.key' => [
                     'sometimes',
+                    'sometimes',
                     'required_if:'.$attributeConsideringRelationType.'.operation,update',
                     'required_if:'.$attributeConsideringRelationType.'.operation,attach',
                     'required_if:'.$attributeConsideringRelationType.'.operation,detach',

--- a/src/Rules/Mutate/Mutate.php
+++ b/src/Rules/Mutate/Mutate.php
@@ -41,7 +41,11 @@ class Mutate extends RestRule
                     new ArrayWithKey($this->resource->getFields($request)),
                 ],
                 $attributeConsideringRelationType.'.key' => [
-                    'sometimes',
+                    'present_if:'.$attributeConsideringRelationType.'.operation,update',
+                    'present_if:'.$attributeConsideringRelationType.'.operation,attach',
+                    'present_if:'.$attributeConsideringRelationType.'.operation,detach',
+                    'present_if:'.$attributeConsideringRelationType.'.operation,toggle',
+                    'present_if:'.$attributeConsideringRelationType.'.operation,sync',
                     'prohibited_if:'.$attributeConsideringRelationType.'.operation,create',
                     'exists:'.$this->resource::newModel()->getTable().','.$this->resource::newModel()->getKeyName(),
                 ],

--- a/src/Rules/Mutate/Mutate.php
+++ b/src/Rules/Mutate/Mutate.php
@@ -42,7 +42,6 @@ class Mutate extends RestRule
                 ],
                 $attributeConsideringRelationType.'.key' => [
                     'sometimes',
-                    'sometimes',
                     'required_if:'.$attributeConsideringRelationType.'.operation,update',
                     'required_if:'.$attributeConsideringRelationType.'.operation,attach',
                     'required_if:'.$attributeConsideringRelationType.'.operation,detach',

--- a/tests/Feature/Controllers/MutateCreateMorphOperationsTest.php
+++ b/tests/Feature/Controllers/MutateCreateMorphOperationsTest.php
@@ -350,6 +350,7 @@ class MutateCreateMorphOperationsTest extends TestCase
             2
         );
     }
+
     public function test_creating_a_resource_with_attaching_empty_morph_many_relation(): void
     {
         $modelToCreate = ModelFactory::new()->makeOne();
@@ -392,8 +393,6 @@ class MutateCreateMorphOperationsTest extends TestCase
             0
         );
     }
-
-
 
     public function test_creating_a_resource_with_updating_morph_many_relation(): void
     {

--- a/tests/Feature/Controllers/MutateCreateMorphOperationsTest.php
+++ b/tests/Feature/Controllers/MutateCreateMorphOperationsTest.php
@@ -350,6 +350,50 @@ class MutateCreateMorphOperationsTest extends TestCase
             2
         );
     }
+    public function test_creating_a_resource_with_attaching_empty_morph_many_relation(): void
+    {
+        $modelToCreate = ModelFactory::new()->makeOne();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(MorphManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/mutate',
+            [
+                'mutate' => [
+                    [
+                        'operation'  => 'create',
+                        'attributes' => [
+                            'name'   => $modelToCreate->name,
+                            'number' => $modelToCreate->number,
+                        ],
+                        'relations' => [
+                            'morphManyRelation' => [
+                                [
+                                    'operation' => 'attach',
+                                    'key'       => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertMutatedResponse(
+            $response,
+            [$modelToCreate],
+        );
+
+        // Here we test that the relation is correctly linked
+        $this->assertEquals(
+            Model::find($response->json('created.0'))->morphManyRelation()->count(),
+            0
+        );
+    }
+
+
 
     public function test_creating_a_resource_with_updating_morph_many_relation(): void
     {

--- a/tests/Feature/Controllers/MutateCreateOperationsTest.php
+++ b/tests/Feature/Controllers/MutateCreateOperationsTest.php
@@ -718,7 +718,6 @@ class MutateCreateOperationsTest extends TestCase
         );
     }
 
-
     public function test_creating_a_resource_with_updating_has_many_relation(): void
     {
         $modelToCreate = ModelFactory::new()->makeOne();

--- a/tests/Feature/Controllers/MutateCreateOperationsTest.php
+++ b/tests/Feature/Controllers/MutateCreateOperationsTest.php
@@ -675,6 +675,50 @@ class MutateCreateOperationsTest extends TestCase
         );
     }
 
+    public function test_creating_a_resource_with_attaching_empty_has_many_relation(): void
+    {
+        $modelToCreate = ModelFactory::new()->makeOne();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/mutate',
+            [
+                'mutate' => [
+                    [
+                        'operation'  => 'create',
+                        'attributes' => [
+                            'name'   => $modelToCreate->name,
+                            'number' => $modelToCreate->number,
+                        ],
+                        'relations' => [
+                            'hasManyRelation' => [
+                                [
+                                    'operation' => 'attach',
+                                    'key'       => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertMutatedResponse(
+            $response,
+            [$modelToCreate],
+        );
+
+        // Here we test that the relation is correctly linked
+        $this->assertEquals(
+            Model::find($response->json('created.0'))->hasManyRelation()->count(),
+            0
+        );
+    }
+
+
     public function test_creating_a_resource_with_updating_has_many_relation(): void
     {
         $modelToCreate = ModelFactory::new()->makeOne();

--- a/tests/Feature/Controllers/MutateUpdateMorphOperationsTest.php
+++ b/tests/Feature/Controllers/MutateUpdateMorphOperationsTest.php
@@ -430,6 +430,51 @@ class MutateUpdateMorphOperationsTest extends TestCase
         );
     }
 
+    public function test_updating_a_resource_with_attaching_empty_morph_many_relation(): void
+    {
+        $modelToUpdate = ModelFactory::new()->createOne();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(MorphManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/mutate',
+            [
+                'mutate' => [
+                    [
+                        'operation'  => 'update',
+                        'key'        => $modelToUpdate->getKey(),
+                        'attributes' => [
+                            'name'   => 'new name',
+                            'number' => 5001,
+                        ],
+                        'relations' => [
+                            'morphManyRelation' => [
+                                [
+                                    'operation' => 'attach',
+                                    'key'       => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertMutatedResponse(
+            $response,
+            [],
+            [$modelToUpdate],
+        );
+
+        // Here we test that the relation is correctly linked
+        $this->assertEquals(
+            Model::find($response->json('updated.0'))->morphManyRelation()->count(),
+            0
+        );
+    }
+
     public function test_updating_a_resource_with_detaching_morph_many_relation(): void
     {
         $modelToUpdate = ModelFactory::new()->createOne();

--- a/tests/Feature/Controllers/MutateUpdateOperationsTest.php
+++ b/tests/Feature/Controllers/MutateUpdateOperationsTest.php
@@ -2510,7 +2510,7 @@ class MutateUpdateOperationsTest extends TestCase
     public function test_updating_a_resource_with_detaching_empty_array_belongs_to_many_relation(): void
     {
         $modelToUpdate = ModelFactory::new()->createOne();
-        $belongsToManyRelationToDetach = BelongsToManyRelationFactory::new()
+        BelongsToManyRelationFactory::new()
             ->recycle($modelToUpdate)
             ->createOne();
 

--- a/tests/Feature/Controllers/MutateUpdateOperationsTest.php
+++ b/tests/Feature/Controllers/MutateUpdateOperationsTest.php
@@ -2510,9 +2510,10 @@ class MutateUpdateOperationsTest extends TestCase
     public function test_updating_a_resource_with_detaching_empty_array_belongs_to_many_relation(): void
     {
         $modelToUpdate = ModelFactory::new()->createOne();
-        BelongsToManyRelationFactory::new()
-            ->recycle($modelToUpdate)
+        $existingRelation = BelongsToManyRelationFactory::new()
             ->createOne();
+
+        $modelToUpdate->belongsToManyRelation()->attach($existingRelation);
 
         Gate::policy(Model::class, GreenPolicy::class);
         Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
@@ -2548,10 +2549,10 @@ class MutateUpdateOperationsTest extends TestCase
             [$modelToUpdate],
         );
 
-        // Here we test that the relation is correctly linked
+        // Here we test that detaching with empty array preserves existing relations
         $this->assertEquals(
-            Model::find($response->json('updated.0'))->belongsToManyRelation()->count(),
-            0
+            1,
+            Model::find($response->json('updated.0'))->belongsToManyRelation()->count()
         );
     }
 

--- a/tests/Feature/Controllers/MutateUpdateOperationsTest.php
+++ b/tests/Feature/Controllers/MutateUpdateOperationsTest.php
@@ -646,6 +646,51 @@ class MutateUpdateOperationsTest extends TestCase
         );
     }
 
+    public function test_updating_a_resource_with_attaching_empty_has_many_relation(): void
+    {
+        $modelToUpdate = ModelFactory::new()->createOne();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/mutate',
+            [
+                'mutate' => [
+                    [
+                        'operation'  => 'update',
+                        'key'        => $modelToUpdate->getKey(),
+                        'attributes' => [
+                            'name'   => 'new name',
+                            'number' => 5001,
+                        ],
+                        'relations' => [
+                            'hasManyRelation' => [
+                                [
+                                    'operation' => 'attach',
+                                    'key'       => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertMutatedResponse(
+            $response,
+            [],
+            [$modelToUpdate],
+        );
+
+        // Here we test that the relation is correctly linked
+        $this->assertEquals(
+            Model::find($response->json('updated.0'))->hasManyRelation()->count(),
+            0
+        );
+    }
+
     public function test_updating_a_resource_with_attaching_has_many_relation_with_required_rules(): void
     {
         $modelToUpdate = ModelFactory::new()->createOne();

--- a/tests/Feature/Controllers/MutateUpdateOperationsTest.php
+++ b/tests/Feature/Controllers/MutateUpdateOperationsTest.php
@@ -1794,15 +1794,6 @@ class MutateUpdateOperationsTest extends TestCase
             Model::find($response->json('updated.0'))->belongsToManyRelation()->count(),
             0
         );
-
-        $this->assertDatabaseHas(
-            $belongsToManySynced->getTable(),
-            ['number' => 5001]
-        );
-        $this->assertDatabaseHas(
-            $modelToUpdate->belongsToManyRelation()->getTable(),
-            ['number' => 20]
-        );
     }
 
     public function test_updating_a_resource_with_syncing_belongs_to_many_relation_without_detaching(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relation "key" is no longer required for create/update/attach/detach/toggle/sync operations, preventing unintended related records when empty relation keys are submitted.

* **Tests**
  * Added comprehensive tests ensuring attach/sync/detach with empty hasMany, morphMany, and belongsToMany keys (including pivot scenarios) results in no related records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->