### PR TITLE
Fix maximum aggregate set at 50

### DIFF
--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -245,7 +245,7 @@ trait PerformSearch
 
 
 
-        return $this->queryBuilder->disableDefaultLimit()->withAggregate([$relation => function (Builder $query) use ($aggregate) {
+        return $this->queryBuilder->withAggregate([$relation => function (Builder $query) use ($aggregate) {
             $resource = $this->resource->relation($aggregate['relation'])?->resource();
 
             $queryBuilder = $this->newQueryBuilder(['resource' => $resource, 'query' => $query]);

--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -243,7 +243,9 @@ trait PerformSearch
             $relation .= ' as '.$aggregate['alias'];
         }
 
-        return $this->queryBuilder->withAggregate([$relation => function (Builder $query) use ($aggregate) {
+
+
+        return $this->queryBuilder->disableDefaultLimit()->withAggregate([$relation => function (Builder $query) use ($aggregate) {
             $resource = $this->resource->relation($aggregate['relation'])?->resource();
 
             $queryBuilder = $this->newQueryBuilder(['resource' => $resource, 'query' => $query]);

--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -245,7 +245,6 @@ trait PerformSearch
 
 
 
-        s
 
         return $this->queryBuilder->withAggregate([$relation => function (Builder $query) use ($aggregate) {
             $resource = $this->resource->relation($aggregate['relation'])?->resource();

--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -245,6 +245,8 @@ trait PerformSearch
 
 
 
+        s
+
         return $this->queryBuilder->withAggregate([$relation => function (Builder $query) use ($aggregate) {
             $resource = $this->resource->relation($aggregate['relation'])?->resource();
 

--- a/src/Rules/Search/SearchAggregate.php
+++ b/src/Rules/Search/SearchAggregate.php
@@ -29,6 +29,9 @@ class SearchAggregate extends RestRule
                     Rule::in(['count', 'min', 'max', 'avg', 'sum', 'exists']),
                 ],
             ],
+
+
+
             !is_null($relationResource) ? [
                 $attribute.'.field' => [
                     'required_if:'.$attribute.'.type,min,max,avg,sum',

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -516,13 +516,13 @@ class SearchAggregatesOperationsTest extends TestCase
         $matchingModel = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
         $matchingModel2 = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
 

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -926,13 +926,13 @@ class SearchAggregatesOperationsTest extends TestCase
         $matchingModel = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
         $matchingModel2 = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
 

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -243,13 +243,13 @@ class SearchAggregatesOperationsTest extends TestCase
         $matchingModel = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(200)
+                    ->count(20)
             )
             ->create()->fresh();
         $matchingModel2 = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(200)
+                    ->count(20)
             )
             ->create()->fresh();
 
@@ -425,13 +425,13 @@ class SearchAggregatesOperationsTest extends TestCase
         $matchingModel = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
         $matchingModel2 = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
 

--- a/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
+++ b/tests/Feature/Controllers/SearchAggregatesOperationsTest.php
@@ -243,13 +243,13 @@ class SearchAggregatesOperationsTest extends TestCase
         $matchingModel = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
         $matchingModel2 = ModelFactory::new()
             ->has(
                 BelongsToManyRelationFactory::new()
-                    ->count(20)
+                    ->count(200)
             )
             ->create()->fresh();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased test data volumes for aggregate-operation tests to better validate aggregate behaviors (count/sum) with larger datasets — related record counts in affected tests raised from 20 to 200 to improve coverage and reliability.
* **Style**
  * Minor whitespace and formatting cleanup with no functional or behavioral impact (non-functional spacing adjustments only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->