### PR TITLE
Fix scout sorting

### DIFF
--- a/src/Concerns/PerformsRestOperations.php
+++ b/src/Concerns/PerformsRestOperations.php
@@ -53,7 +53,7 @@ trait PerformsRestOperations
         $query = app()->make($builder, ['resource' => $resource, 'query' => null])
             ->search($request->input('search', []));
 
-        $responsable = $resource->paginate($query, $request, $resource);
+        $responsable = $resource->paginate($query, $request);
 
         $this->afterSearch($request);
 

--- a/src/Concerns/PerformsRestOperations.php
+++ b/src/Concerns/PerformsRestOperations.php
@@ -53,7 +53,7 @@ trait PerformsRestOperations
         $query = app()->make($builder, ['resource' => $resource, 'query' => null])
             ->search($request->input('search', []));
 
-        $responsable = $resource->paginate($query, $request);
+        $responsable = $resource->paginate($query, $request, $resource);
 
         $this->afterSearch($request);
 

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -29,7 +29,8 @@ trait Paginable
             }
 
             $paginatedQuery = $paginator->getCollection()->toQuery();
-            // We apply query callback to a new builder after pagination because of scout bad ids handling when mapping them to get total count and then set paginator items
+            // Apply query callback after pagination to prevent Scout from mapping all IDs during total count calculation,
+            // which can cause "allowed memory size" errors with large result sets
             $scoutBuilder = (new ScoutBuilder($this))->applyQueryCallback($paginatedQuery, $request->input('search', []));
             $results = $scoutBuilder->get();
 

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -24,7 +24,9 @@ trait Paginable
         if ($query instanceof Builder) {
             $paginator = $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
 
-            if ($paginator->isEmpty()) { return $paginator; }
+            if ($paginator->isEmpty()) {
+                return $paginator;
+            }
 
             $paginatedQuery = $paginator->getCollection()->toQuery();
             // We apply query callback to a new builder after pagination because of scout bad ids handling when mapping them to get total count and then set paginator items

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -2,8 +2,10 @@
 
 namespace Lomkit\Rest\Concerns\Resource;
 
+use Lomkit\Rest\Http\Resource;
 use Laravel\Scout\Builder;
 use Lomkit\Rest\Http\Requests\RestRequest;
+use Lomkit\Rest\Query\ScoutBuilder;
 
 trait Paginable
 {
@@ -12,16 +14,20 @@ trait Paginable
      *
      * @param Illuminate\Database\Eloquent\Builder|\Laravel\Scout\Builder $query
      * @param RestRequest                                                 $request
+     * @param Resource                                                    $resource
      *
      * @return mixed
      */
-    public function paginate($query, RestRequest $request)
+    public function paginate($query, RestRequest $request, Resource $resource)
     {
         $defaultLimit = $this->defaultLimit ?? 50;
 
         // In case we have a scout builder
         if ($query instanceof Builder) {
-            return $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
+            $paginator = $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
+
+            // We apply query callback to a new builder after pagination because of scout bad ids handling when mapping them to get total count and then set paginator items
+            return $paginator->setCollection((new ScoutBuilder($resource, null))->applyQueryCallback($paginator->getCollection()->toQuery(), $request->input('search', []))->get());
         }
 
         return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -2,7 +2,6 @@
 
 namespace Lomkit\Rest\Concerns\Resource;
 
-use Lomkit\Rest\Http\Resource;
 use Laravel\Scout\Builder;
 use Lomkit\Rest\Http\Requests\RestRequest;
 use Lomkit\Rest\Query\ScoutBuilder;
@@ -14,11 +13,10 @@ trait Paginable
      *
      * @param Illuminate\Database\Eloquent\Builder|\Laravel\Scout\Builder $query
      * @param RestRequest                                                 $request
-     * @param Resource                                                    $resource
      *
      * @return mixed
      */
-    public function paginate($query, RestRequest $request, Resource $resource)
+    public function paginate($query, RestRequest $request)
     {
         $defaultLimit = $this->defaultLimit ?? 50;
 
@@ -27,7 +25,7 @@ trait Paginable
             $paginator = $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
 
             // We apply query callback to a new builder after pagination because of scout bad ids handling when mapping them to get total count and then set paginator items
-            return $paginator->setCollection((new ScoutBuilder($resource))->applyQueryCallback($paginator->getCollection()->toQuery(), $request->input('search', []))->get());
+            return $paginator->setCollection((new ScoutBuilder($this))->applyQueryCallback($paginator->getCollection()->toQuery(), $request->input('search', []))->get());
         }
 
         return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -27,7 +27,7 @@ trait Paginable
             $paginator = $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
 
             // We apply query callback to a new builder after pagination because of scout bad ids handling when mapping them to get total count and then set paginator items
-            return $paginator->setCollection((new ScoutBuilder($resource, null))->applyQueryCallback($paginator->getCollection()->toQuery(), $request->input('search', []))->get());
+            return $paginator->setCollection((new ScoutBuilder($resource))->applyQueryCallback($paginator->getCollection()->toQuery(), $request->input('search', []))->get());
         }
 
         return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -27,14 +27,16 @@ trait Paginable
             if ($paginator->isEmpty()) {
                 return $paginator;
             }
-
-            $paginatedQuery = $paginator->getCollection()->toQuery();
+            $ids = $paginator->getCollection()->modelKeys();
+            $paginatedQuery = $this->newModel()->whereKey($ids);
             // Apply query callback after pagination to prevent Scout from mapping all IDs during total count calculation,
             // which can cause "allowed memory size" errors with large result sets
             $scoutBuilder = (new ScoutBuilder($this))->applyQueryCallback($paginatedQuery, $request->input('search', []));
-            $results = $scoutBuilder->get();
+            $results = $scoutBuilder->get()->keyBy($this->newModel()->getKeyName());
+            $order = array_flip($ids);
+            $ordered = $results->sortBy(fn ($model) => $order[$model->getKey()])->values();
 
-            return $paginator->setCollection($results);
+            return $paginator->setCollection($ordered);
         }
 
         return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));

--- a/src/Query/ScoutBuilder.php
+++ b/src/Query/ScoutBuilder.php
@@ -55,7 +55,7 @@ class ScoutBuilder implements QueryBuilder
     }
 
     /**
-     *  Forwads the extra parameters after excluding reserved keys (filters, instructions, sorts, text, and limit)
+     *  Forwards the extra parameters after excluding reserved keys (filters, instructions, sorts, text, and limit)
      *  to the underlying search operation.
      *
      * @param \Laravel\Scout\Builder $query

--- a/src/Query/ScoutBuilder.php
+++ b/src/Query/ScoutBuilder.php
@@ -18,9 +18,7 @@ class ScoutBuilder implements QueryBuilder
      * This method configures the underlying search builder by setting the query text,
      * and conditionally applying filters, sort orders, and additional instructions based
      * on the provided parameters. It also enforces a limit on the number of results,
-     * defaulting to 50 if no limit is specified. Any extra parameters, after excluding
-     * reserved keys (filters, instructions, sorts, text, and limit), are forwarded to the
-     * underlying search operation.
+     * defaulting to 50 if no limit is specified.
      *
      * @param array $parameters An associative array of search criteria, which may include:
      *                          - 'text': An array containing 'value' (search string) and optionally 'trashed' ('with'|'only').
@@ -53,25 +51,34 @@ class ScoutBuilder implements QueryBuilder
             $this->applyInstructions($parameters['instructions']);
         });
 
-        $this->queryBuilder
-            ->query(function (Builder $query) use ($parameters) {
-                app()->make(QueryBuilder::class, ['query' => $query, 'resource' => $this->resource])
-                    ->disableSecurity()
-                    ->search(
-                        collect($parameters)
-                            ->except([
-                                'filters',
-                                'instructions',
-                                'sorts',
-                                'text',
-                                'limit',
-                                'page',
-                            ])
-                            ->all()
-                    );
-            });
-
         return $this->queryBuilder;
+    }
+
+    /**
+     *  Forwads the extra parameters after excluding reserved keys (filters, instructions, sorts, text, and limit)
+     *  to the underlying search operation.
+     *
+     * @param \Laravel\Scout\Builder $query
+     * @param array $parameters
+     *
+     *  @return \Laravel\Scout\Builder The new query builder.
+     */
+    public function applyQueryCallback($query, $parameters)
+    {
+        return app()->make(QueryBuilder::class, ['query' => $query, 'resource' => $this->resource])
+            ->disableSecurity()
+            ->search(
+                collect($parameters)
+                    ->except([
+                        'filters',
+                        'instructions',
+                        'sorts',
+                        'text',
+                        'limit',
+                        'page',
+                    ])
+                    ->all()
+            );
     }
 
     /**

--- a/src/Query/ScoutBuilder.php
+++ b/src/Query/ScoutBuilder.php
@@ -59,9 +59,9 @@ class ScoutBuilder implements QueryBuilder
      *  to the underlying search operation.
      *
      * @param \Laravel\Scout\Builder $query
-     * @param array $parameters
+     * @param array                  $parameters
      *
-     *  @return \Laravel\Scout\Builder The new query builder.
+     * @return \Laravel\Scout\Builder The new query builder.
      */
     public function applyQueryCallback($query, $parameters)
     {

--- a/tests/Unit/LaravelScoutTest.php
+++ b/tests/Unit/LaravelScoutTest.php
@@ -93,7 +93,7 @@ class LaravelScoutTest extends \Lomkit\Rest\Tests\TestCase
                 ],
             ]);
 
-        ($scoutQueryBuilderMock->toBase()->queryCallback)(Model::query());
+        $this->assertNull($scoutQueryBuilderMock->toBase()->queryCallback);
     }
 
     public function test_building_scout_with_trashed()
@@ -116,7 +116,7 @@ class LaravelScoutTest extends \Lomkit\Rest\Tests\TestCase
                 ],
             ]);
 
-        ($scoutQueryBuilderMock->toBase()->queryCallback)(Model::query());
+        $this->assertNull($scoutQueryBuilderMock->toBase()->queryCallback);
     }
 
     public function test_building_scout_only_trashed()
@@ -139,6 +139,6 @@ class LaravelScoutTest extends \Lomkit\Rest\Tests\TestCase
                 ],
             ]);
 
-        ($scoutQueryBuilderMock->toBase()->queryCallback)(Model::query());
+        $this->assertNull($scoutQueryBuilderMock->toBase()->queryCallback);
     }
 }


### PR DESCRIPTION
Closes #207 

The idea of this PR is to keep Scout sorting by applying it again. We now save the ids and create a new query from them to then sort the results by their original order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced pagination logic to handle empty result sets more efficiently and ensure results maintain proper ordering when paginated.
  * Improved query parameter handling with better separation of internal processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->