### PR TITLE
Fix scout sorting

### DIFF
--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -27,14 +27,15 @@ trait Paginable
             if ($paginator->isEmpty()) {
                 return $paginator;
             }
-
-            $paginatedQuery = $paginator->getCollection()->toQuery();
+            $ids = $paginator->getCollection()->modelKeys();
+            $paginatedQuery = $this->newModel()->whereKey($ids);
             // Apply query callback after pagination to prevent Scout from mapping all IDs during total count calculation,
             // which can cause "allowed memory size" errors with large result sets
             $scoutBuilder = (new ScoutBuilder($this))->applyQueryCallback($paginatedQuery, $request->input('search', []));
-            $results = $scoutBuilder->get();
-
-            return $paginator->setCollection($results);
+            $results = $scoutBuilder->get()->keyBy($this->newModel()->getKeyName());
+            $order = array_flip($ids);
+            $ordered = $results->sortBy(fn ($model) => $order[$model->getKey()])->values();
+            return $paginator->setCollection($ordered);
         }
 
         return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));


### PR DESCRIPTION
Closes #207 

The idea of this PR is to keep Scout sorting by applying it again. We now save the ids and create a new query from them to then sort the results by their original order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination result ordering to ensure search results maintain their correct sequence when browsing through pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->