### PR TITLE
Fix Scout sort order in paginate()

### DIFF
--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -28,13 +28,22 @@ trait Paginable
                 return $paginator;
             }
 
-            $paginatedQuery = $paginator->getCollection()->toQuery();
+            $ids = $paginator->getCollection()->modelKeys();
+
+            $paginatedQuery = $this->newModel()->whereKey($ids);
             // Apply query callback after pagination to prevent Scout from mapping all IDs during total count calculation,
             // which can cause "allowed memory size" errors with large result sets
             $scoutBuilder = (new ScoutBuilder($this))->applyQueryCallback($paginatedQuery, $request->input('search', []));
-            $results = $scoutBuilder->get();
 
-            return $paginator->setCollection($results);
+            // The DB query does not guarantee order, so we rebuild the collection
+            // from Scout's ID list to preserve the original sort order.
+            $keyedResults = $scoutBuilder->get()->keyBy($this->newModel()->getKeyName());
+            $ordered = collect($ids)
+                ->map(fn ($id) => $keyedResults->get($id))
+                ->filter()
+                ->values();
+
+            return $paginator->setCollection($ordered);
         }
 
         return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -28,17 +28,17 @@ trait Paginable
                 return $paginator;
             }
 
-            $ids = $paginator->getCollection()->modelKeys();
+            $paginatedQuery = $paginator->getCollection()->toQuery();
 
-            $paginatedQuery = $this->newModel()->whereKey($ids);
             // Apply query callback after pagination to prevent Scout from mapping all IDs during total count calculation,
             // which can cause "allowed memory size" errors with large result sets
             $scoutBuilder = (new ScoutBuilder($this))->applyQueryCallback($paginatedQuery, $request->input('search', []));
+            $results = $scoutBuilder->get();
 
             // The DB query does not guarantee order, so we rebuild the collection
             // from Scout's ID list to preserve the original sort order.
-            $keyedResults = $scoutBuilder->get()->keyBy($this->newModel()->getKeyName());
-            $ordered = collect($ids)
+            $keyedResults = $results->keyBy($this->newModel()->getKeyName());
+            $ordered = collect($paginator->getCollection()->modelKeys())
                 ->map(fn ($id) => $keyedResults->get($id))
                 ->filter()
                 ->values();


### PR DESCRIPTION
Closes #207

This is an alternative fix to #209, addressing the two concerns raised by @GautierDele and CodeRabbit.

## Problem

When using Scout, the `toQuery()` call on the paginated collection reconstructs an Eloquent query that loses Scout's original sort order, returning results in the database's default order instead.

## Approach

Instead of using `toQuery()`, we:
1. Extract the ordered IDs from Scout's paginator with `modelKeys()`
2. Reconstruct the query with `whereKey($ids)` — compatible with all SQL drivers
3. Apply the query callback (filters, scopes, etc.) as before
4. Rebuild the collection from `$ids` using `collect($ids)->map()` to preserve Scout's order

Scout returns IDs in the correct order, but the DB does not preserve that order when fetching models. So we use Scout's ID list as a reference to reorder the results after the DB query.

## Compatibility

- Works with all SQL drivers (MySQL, PostgreSQL, SQLite, SQL Server)
- Single additional query (`whereKey`), no extra HTTP/Scout call
- Preserves existing behavior for non-Scout queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination ordering so search results consistently preserve the original sort and order across pages. This improves predictability when navigating paginated search results, avoids unexpected item reordering, and ensures the displayed sequence matches the intended ranking or sort criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->