### PR TITLE
feat: support unlimited limit (-1) to retrieve all results as a single page

### DIFF
--- a/src/Concerns/Resource/ConfiguresRestParameters.php
+++ b/src/Concerns/Resource/ConfiguresRestParameters.php
@@ -118,6 +118,18 @@ trait ConfiguresRestParameters
     }
 
     /**
+     * Verify if the provided limit is the unlimited one.
+     *
+     * @param int $limit
+     *
+     * @return bool
+     */
+    public function isUnlimitedLimit(int $limit): bool
+    {
+        return $limit === -1;
+    }
+
+    /**
      * Get the resource's limits.
      *
      * @param \Lomkit\Rest\Http\Requests\RestRequest $request

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -3,7 +3,7 @@
 namespace Lomkit\Rest\Concerns\Resource;
 
 use Illuminate\Pagination\Paginator;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Lomkit\Rest\Pagination\LengthAwarePaginator;
 use Laravel\Scout\Builder;
 use Lomkit\Rest\Http\Requests\RestRequest;
 use Lomkit\Rest\Query\ScoutBuilder;

--- a/src/Concerns/Resource/Paginable.php
+++ b/src/Concerns/Resource/Paginable.php
@@ -2,6 +2,8 @@
 
 namespace Lomkit\Rest\Concerns\Resource;
 
+use Illuminate\Pagination\Paginator;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Laravel\Scout\Builder;
 use Lomkit\Rest\Http\Requests\RestRequest;
 use Lomkit\Rest\Query\ScoutBuilder;
@@ -19,10 +21,30 @@ trait Paginable
     public function paginate($query, RestRequest $request)
     {
         $defaultLimit = $this->defaultLimit ?? 50;
+        $limit = $request->input('search.limit', $defaultLimit);
 
         // In case we have a scout builder
         if ($query instanceof Builder) {
-            $paginator = $query->paginate($request->input('search.limit', $defaultLimit), 'page', $request->input('search.page', 1));
+            // No limit: retrieve all results as a single page
+            if ($this->isUnlimitedLimit($limit)) {
+                $model = $this->newModel();
+                $queryBuilder = (new ScoutBuilder($this))->applyQueryCallback(
+                    $model->newQuery(),
+                    $request->input('search', [])
+                );
+
+                $results = $queryBuilder->get();
+
+                return new LengthAwarePaginator(
+                    $results,
+                    $results->count(),
+                    $results->count() ?: 1,
+                    1,
+                    ['path' => Paginator::resolveCurrentPath()]
+                );
+            }
+
+            $paginator = $query->paginate($limit, 'page', $request->input('search.page', 1));
 
             if ($paginator->isEmpty()) {
                 return $paginator;
@@ -37,6 +59,19 @@ trait Paginable
             return $paginator->setCollection($results);
         }
 
-        return $query->paginate($request->input('search.limit', $defaultLimit), ['*'], 'page', $request->input('search.page', 1));
+        // No limit: retrieve all results as a single page
+        if ($this->isUnlimitedLimit($limit)) {
+            $results = $query->get();
+
+            return new LengthAwarePaginator(
+                $results,
+                $results->count(),
+                $results->count() ?: 1,
+                1,
+                ['path' => Paginator::resolveCurrentPath()]
+            );
+        }
+
+        return $query->paginate($limit, ['*'], 'page', $request->input('search.page', 1));
     }
 }

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -32,16 +32,6 @@ class LengthAwarePaginator extends BaseLengthAwarePaginator
     }
 
     /**
-     * Get the number of items shown per page.
-     *
-     * @return int
-     */
-    public function perPage(): int
-    {
-        return $this->total() === 0 ? 0 : parent::perPage();
-    }
-
-    /**
      * Get the meta of items being paginated.
      *
      * @return array
@@ -63,7 +53,7 @@ class LengthAwarePaginator extends BaseLengthAwarePaginator
             'data'         => $this->items->toArray(),
             'from'         => $this->firstItem(),
             'last_page'    => $this->lastPage(),
-            'per_page'     => $this->perPage(),
+            'per_page'     => $this->total() === 0 ? 0 : $this->perPage(),
             'to'           => $this->lastItem(),
             'total'        => $this->total(),
             'meta'         => $this->meta(),

--- a/src/Pagination/LengthAwarePaginator.php
+++ b/src/Pagination/LengthAwarePaginator.php
@@ -32,6 +32,16 @@ class LengthAwarePaginator extends BaseLengthAwarePaginator
     }
 
     /**
+     * Get the number of items shown per page.
+     *
+     * @return int
+     */
+    public function perPage(): int
+    {
+        return $this->total() === 0 ? 0 : parent::perPage();
+    }
+
+    /**
      * Get the meta of items being paginated.
      *
      * @return array


### PR DESCRIPTION
## Problem
There was no way to retrieve all results in a single request.

## Approach
- Add `isUnlimitedLimit()` in `ConfiguresRestParameters` to centralize the `-1` 
  sentinel value logic
- In `Paginable`, when `isUnlimitedLimit()` is true, bypass pagination and wrap 
  results in a `LengthAwarePaginator` to preserve a consistent response format
- Return `0` when total is `0`, avoiding the semantically incorrect `per_page: 1` on empty results

## Compatibility
- Works with all SQL drivers (MySQL, PostgreSQL, SQLite, SQL Server)
- Works with both Scout and Eloquent query paths
- Requires `-1` to be explicitly declared in the resource's `limits()` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an "unlimited" pagination option that returns all matching results as a single page.

* **Bug Fixes**
  * Ensured consistent limit handling across different query types for predictable pagination.

* **Other**
  * Pagination metadata now reports zero items-per-page when there are no results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->