### PR TITLE
fix: normalize empty search text value before validation

### DIFF
--- a/src/Http/Requests/SearchRequest.php
+++ b/src/Http/Requests/SearchRequest.php
@@ -7,6 +7,21 @@ use Lomkit\Rest\Rules\Search\Search;
 class SearchRequest extends RestRequest
 {
     /**
+     * Normalize the search input before validation.
+     * Removes empty or whitespace-only text values to prevent
+     * invalid Elasticsearch queries being sent by ScoutBuilder.
+     */
+    protected function prepareForValidation(): void
+    {
+        $search = $this->input('search', []);
+
+        if (trim(($search['text']['value'] ?? '')) === '') {
+            unset($search['text']);
+            $this->merge(['search' => $search]);
+        }
+    }
+
+    /**
      * Define the validation rules for the search request.
      *
      * @return array


### PR DESCRIPTION
# fix: normalize empty search text value before validation

## Problem

When `search.text.value` is sent as an empty string, whitespace, or `null`, `$request->has('search.text')` still returns `true` in the `search` method of `RestController`.

This causes `ScoutBuilder` to be selected and send a `match` query with a `null` value to Elasticsearch, resulting in the following 400 error:

```
[match] unknown token [VALUE_NULL] after [query]
```

## Reproduction

Send any of the following payloads to the search endpoint:

```json
{ "search": { "text": { "value": "" } } }
{ "search": { "text": { "value": " " } } }
{ "search": { "text": { "value": null } } }
```

## Fix

Normalize the input in `prepareForValidation` inside `SearchRequest` by removing `search.text` when its value is empty, whitespace, or `null` — before validation and builder selection occur.

```php
protected function prepareForValidation(): void
{
    $search = $this->input('search', []);

    if (trim(($search['text']['value'] ?? '')) === '') {
        unset($search['text']);
        $this->merge(['search' => $search]);
    }
}
```

- The `?? ''` handles a missing or `null` value
- `trim()` handles whitespace-only strings
- Once `search.text` is stripped, `$request->has('search.text')` returns `false` and the controller correctly falls back to `QueryBuilder`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or whitespace-only search inputs to prevent validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->