### PR TITLE
Drop Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ '8.2', '8.3', '8.4', '8.5' ]
-        laravel-version: [ '^11.0', '^12.0', '^13.0' ]
+        laravel-version: [ '^12.0', '^13.0' ]
         database: [ 'sqlite', 'mysql', 'pgsql' ]
         exclude:
           - php-version: '8.2'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Laravel Rest Api is an elegant way to expose your app through an API, it takes f
 
 ## Requirements
 
-PHP 8.2+ and Laravel 11+
+PHP 8.2+ and Laravel 12+
 
 ## Documentation, Installation, and Usage Instructions
 

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
   "require": {
     "php": "^8.2",
     "ext-json": "*",
-    "laravel/framework": "^11|^12|^13"
+    "laravel/framework": "^12|^13"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^6.0|^7.0",
     "laravel/scout": "^10|^11",
-    "orchestra/testbench": "^9|^10|^11",
+    "orchestra/testbench": "^10|^11",
     "phpunit/phpunit": "^10|^11|^12|^13"
   },
   "suggest": {

--- a/resources/boost/skills/laravel-rest-api/SKILL.md
+++ b/resources/boost/skills/laravel-rest-api/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when working with the `lomkit/laravel-rest-api` pack
 
 `lomkit/laravel-rest-api` exposes Eloquent models through a small, fixed set of POST-driven endpoints. Instead of writing one controller per use case, you declare a **Resource** (what is exposed and how it can be queried/mutated) and a thin **Controller** that binds the resource to a route prefix. The package wires CRUD, search, batch mutations, custom actions, soft-delete handling, policy-based authorization and OpenAPI documentation on top of that pair.
 
-Requirements: PHP 8.2+, Laravel 11/12/13.
+Requirements: PHP 8.2+, Laravel 12/13.
 
 Official documentation: https://laravel-rest-api.lomkit.com/
 


### PR DESCRIPTION
## Why

Laravel 11 is no longer actively supported, and its releases are now flagged by security advisories. Composer's default `policy.advisories.block` therefore refuses to install any `laravel/framework` 11.x version, which breaks the `^11.0` CI matrix **at the dependency-resolution step, before a single test runs**:

> Root composer.json requires laravel/framework ^11.0, found laravel/framework[v11.0.0, …, v11.54.0] but these were not loaded, because they are affected by security advisories (…).

With every Laravel 11 blocked, `orchestra/testbench` (v9 → Laravel 11, v10 → Laravel 12, v11 → PHP 8.3) has nothing to bind to and the whole install collapses. This affects `main` too, not just PRs.

## Change

Drop Laravel 11 from the supported range:

- **composer.json**: `laravel/framework` → `^12|^13`; `orchestra/testbench` → `^10|^11` (drops the v9 line, which targets Laravel 11)
- **.github/workflows/tests.yml**: remove `^11.0` from the CI matrix
- **README.md / SKILL.md**: bump the stated minimum to Laravel 12

## Verification

Full test suite run in Docker on both matrix corners — **489 tests, 2380 assertions, all green**:

- Laravel 12.63 / PHP 8.2 / testbench 10.11
- Laravel 13.19 / PHP 8.4 / testbench 11.1
