### PR TITLE
Fix authorization cache poisoning (cached DENY read as ALLOW)

### DIFF
--- a/src/Concerns/Authorizable.php
+++ b/src/Concerns/Authorizable.php
@@ -23,33 +23,7 @@ trait Authorizable
      */
     public function authorizeTo($ability, $model)
     {
-        if ($this->isAuthorizingEnabled()) {
-            $resolver = function () use ($ability, $model) {
-                return Gate::authorize($ability, $model);
-            };
-
-            if ($this->isAuthorizationCacheEnabled()) {
-                $gatePasses = Cache::remember(
-                    $this->getAuthorizationCacheKey(
-                        app(RestRequest::class),
-                        sprintf(
-                            '%s.%s.%s',
-                            $ability,
-                            $model instanceof Model ? Str::snake((new \ReflectionClass($model))->getShortName()) : $model,
-                            $model instanceof Model ? $model->getKey() : null,
-                        )
-                    ),
-                    $this->cacheAuthorizationFor(),
-                    $resolver
-                );
-            } else {
-                $gatePasses = $resolver();
-            }
-
-            if (!$gatePasses) {
-                Response::deny()->authorize();
-            }
-        }
+        $this->authorizedTo($ability, $model)->authorize();
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes a **critical authorization bypass**: with the default-on authorization cache + `gates` features, a cached *denied* decision was read back as *allowed* by the enforcement path, escalating **view → update / delete / forceDelete / restore** on any record the caller can already see.

## Root cause

`authorizeTo()` (enforcement) and `authorizedTo()` (the read-only `gates` display feature) build the **identical** cache key but stored/interpreted values differently:

- `authorizedTo()` caches `Gate::inspect()` results — an `Illuminate\Auth\Access\Response` object for **both** allowed *and* denied outcomes (it never throws).
- `authorizeTo()` read that cached value and only tested it for **truthiness** (`if (!$gatePasses)`).

A `Response` object is **always truthy** in PHP, even when it represents a denial. So an attacker could prime a *deny* into the shared cache via the client-controlled `search.gates` field, and within the cache TTL the enforcement path would read that denied `Response`, see a truthy value, and let the operation through.

### Exploit sketch

```http
POST /api/posts/search
{"search":{"filters":[{"field":"id","operator":"=","value":5}],"gates":["delete","update"]}}
```
Serializing the response caches a **denied** `Response` under `...delete.post.5.{attackerId}`. Then, within the TTL:
```http
DELETE /api/posts/5
```
`authorizeTo('delete', post5)` reads the cached denied `Response` → truthy → no exception → **the delete proceeds**.

## Fix

`authorizeTo()` now delegates to `authorizedTo()` and honors the returned `Response`'s **outcome** via `->authorize()` (which throws `AuthorizationException` on denial), instead of its truthiness. Both paths now share a single, consistent decision, so a cached deny can no longer satisfy enforcement.

This is **behavior-preserving** for the legitimate path: Laravel's `Gate::authorize()` is itself `inspect(...)->authorize()`, so the thrown exception type and allow/deny semantics are unchanged. It also removes the duplicated cache block that was the source of the divergence.
