### PR TITLE
✨ feat: allow aliasing includes to load a relation

### DIFF
--- a/resources/boost/skills/laravel-rest-api/SKILL.md
+++ b/resources/boost/skills/laravel-rest-api/SKILL.md
@@ -223,7 +223,9 @@ Frontends typically call `details` once to drive form rendering, then `search`/`
       {"relation": "posts",
        "filters":  [{"field": "id", "operator": "in", "value": [1, 3]}],
        "sorts":    [{"field": "created_at", "direction": "desc"}],
-       "limit":    2}
+       "limit":    2},
+      {"relation": "posts", "alias": "draftPosts",
+       "filters":  [{"field": "published", "value": false}]}
     ],
     "aggregates": [
       {"relation": "stars", "type": "max", "field": "rate",
@@ -243,6 +245,7 @@ Frontends typically call `details` once to drive form rendering, then `search`/`
 **Filter `type`**: `and` (default) or `or`. Use `nested` to group filters with their own logical operator. `field` may traverse declared relations and pivot data (`user.posts.id`, `languages.pivot.boolean`).
 **Aggregate `type`** values: `min`, `max`, `avg`, `sum`, `count`, `exists`. `field` is required for `min/max/avg/sum`, omit for `count/exists`.
 **`includes`** can recursively re-use `filters`, `sorts`, `scopes`, `limit`, `selects` — but **not nested `includes`** (load chained relations as separate include entries).
+**Include `alias`** renames the response key for that include, which lets the same relation appear several times under different constraints. It must look like an identifier (`^[A-Za-z_][A-Za-z0-9_]*$`), be unique across the includes, and not collide with a field, a relation, or the gates key of the resource. It is used verbatim — no snake_casing — and is rejected on a dotted relation path (use a nested include there).
 **`gates`** asks the server to evaluate the listed policy abilities per row and embed the result under the configured key (default `gates`); with `rest.gates.message.enabled = true` the value becomes `{allowed: bool, message: string}`.
 **`text`** triggers the Scout path; only models using `Laravel\Scout\Searchable` accept it, and some standard search features become Scout-driver-dependent.
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -78,29 +78,24 @@ class Response implements Responsable
      */
     public function modelToResponse(Model $model, Resource $resource, array $requestArray, ?Relation $relation = null)
     {
-        $currentRequestArray = $relation === null ? $requestArray : collect($requestArray['includes'] ?? [])
-            ->first(function ($include) use ($relation) {
-                return preg_match('/(?:\.\b)?'.$relation->relation.'\b/', $include['relation']);
-            }) ?? [];
-
         return array_merge(
             // toArray to take advantage of Laravel's logic
             collect($model->attributesToArray())
                 ->only(
                     array_merge(
-                        isset($currentRequestArray['selects']) ?
-                                collect($currentRequestArray['selects'])->pluck('field')->toArray() :
+                        isset($requestArray['selects']) ?
+                                collect($requestArray['selects'])->pluck('field')->toArray() :
                                 $resource->getFields(app()->make(RestRequest::class)),
                         // Here we add the aggregates
-                        collect($currentRequestArray['aggregates'] ?? [])
+                        collect($requestArray['aggregates'] ?? [])
                             ->map(function ($aggregate) {
                                 return $aggregate['alias'] ?? Str::snake($aggregate['relation']).'_'.$aggregate['type'].(isset($aggregate['field']) ? '_'.$aggregate['field'] : '');
                             })
                             ->toArray()
                     )
                 )
-                ->when($resource->isGatingEnabled() && isset($currentRequestArray['gates']), function ($attributes) use ($currentRequestArray, $resource, $model) {
-                    $currentRequestArrayWithoutCreate = collect($currentRequestArray['gates'])->reject(fn ($value) => $value === 'create')->toArray();
+                ->when($resource->isGatingEnabled() && isset($requestArray['gates']), function ($attributes) use ($requestArray, $resource, $model) {
+                    $currentRequestArrayWithoutCreate = collect($requestArray['gates'])->reject(fn ($value) => $value === 'create')->toArray();
 
                     return $attributes->put(
                         config('rest.gates.key'),
@@ -109,8 +104,14 @@ class Response implements Responsable
                 })
                 ->toArray(),
             collect($model->getRelations())
-                ->mapWithKeys(function ($modelRelation, $relationName) use ($currentRequestArray, $relation, $resource) {
-                    $key = Str::snake($relationName);
+                ->mapWithKeys(function ($modelRelation, $relationName) use ($requestArray, $relation, $resource) {
+                    $currentInclude = collect($requestArray['includes'] ?? [])
+                        ->first(function ($include) use ($relationName) {
+                            return ($include['alias'] ?? $include['relation']) === $relationName;
+                        });
+
+                    $realRelation = $currentInclude['relation'] ?? $relationName;
+                    $key = $currentInclude['alias'] ?? Str::snake($realRelation);
 
                     if (is_null($modelRelation)) {
                         return [
@@ -124,7 +125,7 @@ class Response implements Responsable
                         ];
                     }
 
-                    $relationConcrete = $resource->relation($relationName);
+                    $relationConcrete = $resource->relation($realRelation);
                     $relationResource = $relationConcrete->resource();
 
                     if ($modelRelation instanceof Model) {
@@ -132,7 +133,7 @@ class Response implements Responsable
                             $key => $this->modelToResponse(
                                 $modelRelation,
                                 $relationResource,
-                                $currentRequestArray,
+                                $currentInclude ?? [],
                                 $relationConcrete
                             ),
                         ];
@@ -140,7 +141,7 @@ class Response implements Responsable
 
                     return [
                         $key => $modelRelation
-                            ->map(fn ($collectionRelation) => $this->modelToResponse($collectionRelation, $relationResource, $currentRequestArray, $relationConcrete))
+                            ->map(fn ($collectionRelation) => $this->modelToResponse($collectionRelation, $relationResource, $currentInclude ?? [], $relationConcrete))
                             ->toArray(),
                     ];
                 })

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -127,13 +127,14 @@ class Response implements Responsable
 
                     $relationConcrete = $resource->relation($realRelation);
                     $relationResource = $relationConcrete->resource();
+                    $nestedRequestArray = $this->requestArrayForRelation($requestArray, $currentInclude, $relationName);
 
                     if ($modelRelation instanceof Model) {
                         return [
                             $key => $this->modelToResponse(
                                 $modelRelation,
                                 $relationResource,
-                                $currentInclude ?? [],
+                                $nestedRequestArray,
                                 $relationConcrete
                             ),
                         ];
@@ -141,12 +142,46 @@ class Response implements Responsable
 
                     return [
                         $key => $modelRelation
-                            ->map(fn ($collectionRelation) => $this->modelToResponse($collectionRelation, $relationResource, $currentInclude ?? [], $relationConcrete))
+                            ->map(fn ($collectionRelation) => $this->modelToResponse($collectionRelation, $relationResource, $nestedRequestArray, $relationConcrete))
                             ->toArray(),
                     ];
                 })
                 ->toArray()
         );
+    }
+
+    /**
+     * Build the request array a relation is rendered with.
+     *
+     * A dotted include declares its parameters for the deepest relation of the path, the same way
+     * the query applies them, so every level above only forwards the remaining path downwards.
+     *
+     * @param array      $requestArray   Request parameters of the level being rendered.
+     * @param array|null $currentInclude The include matching the relation, if any.
+     * @param string     $relationName   The name the relation is loaded under.
+     *
+     * @return array The request parameters to render the relation with.
+     */
+    protected function requestArrayForRelation(array $requestArray, ?array $currentInclude, string $relationName): array
+    {
+        $forwardedIncludes = collect($requestArray['includes'] ?? [])
+            ->filter(function ($include) use ($relationName) {
+                return Str::contains($include['relation'], '.')
+                    && Str::before($include['relation'], '.') === $relationName;
+            })
+            ->map(function ($include) {
+                return array_merge($include, ['relation' => Str::after($include['relation'], '.')]);
+            })
+            ->values()
+            ->all();
+
+        $nestedRequestArray = $currentInclude ?? [];
+
+        if (!empty($forwardedIncludes)) {
+            $nestedRequestArray['includes'] = array_merge($nestedRequestArray['includes'] ?? [], $forwardedIncludes);
+        }
+
+        return $nestedRequestArray;
     }
 
     public function toResponse($request)

--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -209,6 +209,14 @@ trait PerformSearch
      */
     public function include($include)
     {
+        if (isset($include['alias'])) {
+            return $this->queryBuilder->afterQuery(function ($models) use ($include) {
+                $this->includeAliased($models, $include);
+
+                return $models;
+            });
+        }
+
         return $this->queryBuilder->with($include['relation'], function (Relation $query) use ($include) {
             $resource = $this->resource->relation($include['relation'])?->resource();
 
@@ -216,6 +224,33 @@ trait PerformSearch
 
             return $queryBuilder->search($include);
         });
+    }
+
+    /**
+     * Manually eager load an include under its alias key.
+     *
+     * @param \Illuminate\Support\Collection $models  The parent models to hydrate.
+     * @param array                          $include The include definition, containing 'relation' and 'alias'.
+     */
+    protected function includeAliased($models, array $include): void
+    {
+        $models = $models->all();
+
+        if (empty($models)) {
+            return;
+        }
+
+        $relation = reset($models)->{$include['relation']}();
+        $relation->addEagerConstraints($models);
+
+        $resource = $this->resource->relation($include['relation'])?->resource();
+        $this->newQueryBuilder(['resource' => $resource, 'query' => $relation])->search($include);
+
+        $relation->match(
+            $relation->initRelation($models, $include['alias']),
+            $relation->getEager(),
+            $include['alias']
+        );
     }
 
     /**

--- a/src/Query/Traits/PerformSearch.php
+++ b/src/Query/Traits/PerformSearch.php
@@ -4,6 +4,7 @@ namespace Lomkit\Rest\Query\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Lomkit\Rest\Http\Requests\RestRequest;
 
@@ -229,10 +230,10 @@ trait PerformSearch
     /**
      * Manually eager load an include under its alias key.
      *
-     * @param \Illuminate\Support\Collection $models  The parent models to hydrate.
-     * @param array                          $include The include definition, containing 'relation' and 'alias'.
+     * @param Collection $models  The parent models to hydrate.
+     * @param array      $include The include definition, containing 'relation' and 'alias'.
      */
-    protected function includeAliased($models, array $include): void
+    protected function includeAliased(Collection $models, array $include): void
     {
         $models = $models->all();
 
@@ -240,17 +241,48 @@ trait PerformSearch
             return;
         }
 
-        $relation = reset($models)->{$include['relation']}();
+        $relationName = $include['relation'];
+        $alias = $include['alias'];
+
+        // Constraints must be disabled while instantiating, otherwise the relation is scoped
+        // to the model it was built from and the other parents resolve to nothing.
+        $relation = Relation::noConstraints(function () use ($models, $relationName) {
+            return reset($models)->newInstance()->{$relationName}();
+        });
+
         $relation->addEagerConstraints($models);
 
-        $resource = $this->resource->relation($include['relation'])?->resource();
+        $resource = $this->resource->relation($relationName)?->resource();
         $this->newQueryBuilder(['resource' => $resource, 'query' => $relation])->search($include);
 
+        // Matching has to happen under the real relation name: MorphTo hydrates parents from
+        // getEager() using that name and ignores the one given to match(). The results are moved
+        // to the alias afterwards, restoring whatever the same relation held before.
+        $loadedBeforeAliasing = [];
+
+        foreach ($models as $index => $model) {
+            if ($model->relationLoaded($relationName)) {
+                $loadedBeforeAliasing[$index] = $model->getRelation($relationName);
+            }
+        }
+
         $relation->match(
-            $relation->initRelation($models, $include['alias']),
+            $relation->initRelation($models, $relationName),
             $relation->getEager(),
-            $include['alias']
+            $relationName
         );
+
+        foreach ($models as $index => $model) {
+            $model->setRelation($alias, $model->getRelation($relationName));
+
+            if (array_key_exists($index, $loadedBeforeAliasing)) {
+                $model->setRelation($relationName, $loadedBeforeAliasing[$index]);
+
+                continue;
+            }
+
+            $model->unsetRelation($relationName);
+        }
     }
 
     /**

--- a/src/Rules/Search/SearchInclude.php
+++ b/src/Rules/Search/SearchInclude.php
@@ -28,6 +28,10 @@ class SearchInclude extends RestRule
                 $attribute.'.text' => [
                     'prohibited',
                 ],
+                $attribute.'.alias' => [
+                    'sometimes',
+                    'string',
+                ],
             ]
         );
     }

--- a/src/Rules/Search/SearchInclude.php
+++ b/src/Rules/Search/SearchInclude.php
@@ -31,6 +31,13 @@ class SearchInclude extends RestRule
                 $attribute.'.alias' => [
                     'sometimes',
                     'string',
+                    'max:255',
+                    // The alias is used verbatim as a model relation key and as a response key,
+                    // so it is restricted to what a relation name could have been.
+                    'regex:/^[A-Za-z_][A-Za-z0-9_]*$/',
+                    (new SearchIncludeAlias())
+                        ->setResource($this->resource)
+                        ->setRelation($value['relation'] ?? ''),
                 ],
             ]
         );

--- a/src/Rules/Search/SearchIncludeAlias.php
+++ b/src/Rules/Search/SearchIncludeAlias.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Lomkit\Rest\Rules\Search;
+
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Lomkit\Rest\Http\Requests\RestRequest;
+use Lomkit\Rest\Http\Resource;
+use Lomkit\Rest\Relations\Relation;
+
+class SearchIncludeAlias implements DataAwareRule, ValidationRule
+{
+    /**
+     * The data under validation.
+     */
+    protected array $data = [];
+
+    /**
+     * The resource instance.
+     */
+    protected Resource $resource;
+
+    /**
+     * The relation the alias is applied to.
+     */
+    protected string $relation;
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        // A nested relation is loaded through its parent, so there is no single level the alias
+        // could key into. The equivalent nested include carries the alias unambiguously.
+        if (Str::contains($this->relation, '.')) {
+            $fail('The alias is not allowed on a nested relation, use a nested include instead.');
+
+            return;
+        }
+
+        if ($value === config('rest.gates.key')) {
+            $fail('The alias is reserved.');
+
+            return;
+        }
+
+        if (in_array($value, $this->resource->getFields(app()->make(RestRequest::class)), true)) {
+            $fail('The alias conflicts with a field of this resource.');
+
+            return;
+        }
+
+        if (in_array($value, $this->relationNames(), true)) {
+            $fail('The alias conflicts with a relation of this resource.');
+
+            return;
+        }
+
+        // Two includes resolving to the same key would silently overwrite each other.
+        if ($this->timesUsedAmongSiblings($attribute, $value) > 1) {
+            $fail('The alias is already used by another include.');
+        }
+    }
+
+    /**
+     * Get the relation names exposed by the resource.
+     */
+    protected function relationNames(): array
+    {
+        return collect($this->resource->getRelations(app()->make(RestRequest::class)))
+            ->map(function (Relation $relation) {
+                return $relation->relation;
+            })
+            ->all();
+    }
+
+    /**
+     * Count how many includes of the same level declare the given alias.
+     */
+    protected function timesUsedAmongSiblings(string $attribute, mixed $value): int
+    {
+        $includesKey = Str::beforeLast(Str::beforeLast($attribute, '.'), '.');
+
+        return collect(Arr::get($this->data, $includesKey, []))
+            ->filter(function ($include) use ($value) {
+                return is_array($include) && ($include['alias'] ?? null) === $value;
+            })
+            ->count();
+    }
+
+    /**
+     * Set the data under validation.
+     */
+    public function setData(array $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Set the current resource.
+     */
+    public function setResource(Resource $resource): static
+    {
+        $this->resource = $resource;
+
+        return $this;
+    }
+
+    /**
+     * Set the relation the alias is applied to.
+     */
+    public function setRelation(string $relation): static
+    {
+        $this->relation = $relation;
+
+        return $this;
+    }
+}

--- a/src/Scramble/LomkitLaravelRestApiOperationExtension.php
+++ b/src/Scramble/LomkitLaravelRestApiOperationExtension.php
@@ -180,6 +180,10 @@ class LomkitLaravelRestApiOperationExtension extends OperationExtension
                                 ? new StringType()
                                 : (new StringType())->enum($relationEnum)->setDescription($relationDesc)
                         )
+                        ->addProperty(
+                            'alias',
+                            (new StringType())->setDescription('Optional output key for this include. Allows including the same relation several times under different keys.')
+                        )
                         ->addProperty('limit', new IntegerType())
                         ->addProperty('filters', new ArrayType())
                         ->addProperty('sorts', new ArrayType())

--- a/src/Scramble/LomkitLaravelRestApiOperationExtension.php
+++ b/src/Scramble/LomkitLaravelRestApiOperationExtension.php
@@ -182,7 +182,7 @@ class LomkitLaravelRestApiOperationExtension extends OperationExtension
                         )
                         ->addProperty(
                             'alias',
-                            (new StringType())->setDescription('Optional output key for this include. Allows including the same relation several times under different keys.')
+                            (new StringType())->setDescription('Optional output key for this include, used verbatim. Allows including the same relation several times under different keys. Must match ^[A-Za-z_][A-Za-z0-9_]*$, be unique across the includes, and not collide with a field, a relation or the gates key. Not allowed on a dotted relation path.')
                         )
                         ->addProperty('limit', new IntegerType())
                         ->addProperty('filters', new ArrayType())

--- a/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
+++ b/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
@@ -901,4 +901,236 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
             ]
         );
     }
+
+    public function test_including_same_relation_twice_with_different_aliases_and_filters(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(
+                HasManyRelationFactory::new()
+                    ->state(['number' => 10000])
+            )
+            ->has(
+                HasManyRelationFactory::new()
+                    ->state(['number' => 20000])
+            )
+            ->create()->fresh();
+
+        $matchingModel2 = ModelFactory::new()->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        [
+                            'relation' => 'hasManyRelation',
+                            'alias'    => 'highNumber',
+                            'filters'  => [
+                                ['field' => 'number', 'value' => 10000],
+                            ],
+                        ],
+                        [
+                            'relation' => 'hasManyRelation',
+                            'alias'    => 'lowNumber',
+                            'filters'  => [
+                                ['field' => 'number', 'value' => 20000],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $relationWithNumber = function ($number) use ($matchingModel) {
+            return $matchingModel->hasManyRelation()
+                ->where('number', $number)
+                ->orderBy('id')
+                ->get()
+                ->map(function ($relation) {
+                    return $relation->only(
+                        (new HasManyResource())->getFields(app()->make(RestRequest::class))
+                    );
+                })->toArray();
+        };
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                [
+                    'highNumber' => $relationWithNumber(10000),
+                    'lowNumber'  => $relationWithNumber(20000),
+                ],
+                [
+                    'highNumber' => [],
+                    'lowNumber'  => [],
+                ],
+            ]
+        );
+    }
+
+    public function test_including_relation_with_alias_uses_verbatim_key(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(HasManyRelationFactory::new())
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        [
+                            'relation' => 'hasManyRelation',
+                            'alias'    => 'myCamelAlias',
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+        $this->assertArrayHasKey('myCamelAlias', $response->json('data.0'));
+        $this->assertArrayNotHasKey('my_camel_alias', $response->json('data.0'));
+        $this->assertArrayNotHasKey('has_many_relation', $response->json('data.0'));
+        $this->assertCount(1, $response->json('data.0.myCamelAlias'));
+    }
+
+    public function test_including_nested_relation_with_alias(): void
+    {
+        $belongsTo = BelongsToRelationFactory::new()->create();
+        $matchingModel = ModelFactory::new()
+            ->for($belongsTo)
+            ->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        [
+                            'relation' => 'belongsToRelation',
+                            'includes' => [
+                                ['relation' => 'models', 'alias' => 'linkedModels'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+        $this->assertArrayHasKey('belongs_to_relation', $response->json('data.0'));
+        $this->assertArrayHasKey('linkedModels', $response->json('data.0.belongs_to_relation'));
+        $this->assertArrayNotHasKey('models', $response->json('data.0.belongs_to_relation'));
+    }
+
+    public function test_including_belongs_to_relation_with_alias(): void
+    {
+        $belongsTo = BelongsToRelationFactory::new()->create();
+        $matchingModel = ModelFactory::new()
+            ->for($belongsTo)
+            ->create()->fresh();
+
+        $matchingModel2 = ModelFactory::new()->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'belongsToRelation', 'alias' => 'owner'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                [
+                    'owner' => $matchingModel->belongsToRelation->only(
+                        (new BelongsToResource())->getFields(app()->make(RestRequest::class))
+                    ),
+                ],
+                [
+                    'owner' => null,
+                ],
+            ]
+        );
+    }
+
+    public function test_including_belongs_to_many_relation_with_alias_keeps_pivot(): void
+    {
+        $matchingModel = ModelFactory::new()
+            ->has(BelongsToManyRelationFactory::new()->count(2))
+            ->create()->fresh();
+        $pivotAccessor = $matchingModel->belongsToManyRelation()->getPivotAccessor();
+
+        $matchingModel2 = ModelFactory::new()->create()->fresh();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'belongsToManyRelation', 'alias' => 'tags'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $this->assertResourcePaginated(
+            $response,
+            [$matchingModel, $matchingModel2],
+            new ModelResource(),
+            [
+                [
+                    'tags' => $matchingModel->belongsToManyRelation()
+                        ->orderBy('id', 'desc')
+                        ->get()
+                        ->map(function ($relation) use ($pivotAccessor) {
+                            return collect($relation->only(
+                                array_merge((new BelongsToManyResource())->getFields(app()->make(RestRequest::class)), [$pivotAccessor])
+                            ))
+                                ->pipe(function ($relation) use ($pivotAccessor) {
+                                    $relation[$pivotAccessor] = collect($relation[$pivotAccessor]->toArray())
+                                        ->only(
+                                            (new ModelResource())->relation('belongsToManyRelation')->getPivotFields()
+                                        );
+
+                                    return $relation;
+                                });
+                        })
+                        ->toArray(),
+                ],
+                [
+                    'tags' => [],
+                ],
+            ]
+        );
+    }
 }

--- a/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
+++ b/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
@@ -15,6 +15,7 @@ use Lomkit\Rest\Tests\Support\Database\Factories\HasOneOfManyRelationFactory;
 use Lomkit\Rest\Tests\Support\Database\Factories\HasOneRelationFactory;
 use Lomkit\Rest\Tests\Support\Database\Factories\ModelFactory;
 use Lomkit\Rest\Tests\Support\Database\Factories\ModelWithFactory;
+use Lomkit\Rest\Tests\Support\Database\Factories\MorphToRelationFactory;
 use Lomkit\Rest\Tests\Support\Models\BelongsToManyRelation;
 use Lomkit\Rest\Tests\Support\Models\BelongsToRelation;
 use Lomkit\Rest\Tests\Support\Models\HasManyRelation;
@@ -23,6 +24,7 @@ use Lomkit\Rest\Tests\Support\Models\HasOneOfManyRelation;
 use Lomkit\Rest\Tests\Support\Models\HasOneRelation;
 use Lomkit\Rest\Tests\Support\Models\Model;
 use Lomkit\Rest\Tests\Support\Models\ModelWith;
+use Lomkit\Rest\Tests\Support\Models\MorphToRelation;
 use Lomkit\Rest\Tests\Support\Policies\GreenPolicy;
 use Lomkit\Rest\Tests\Support\Rest\Resources\BelongsToManyResource;
 use Lomkit\Rest\Tests\Support\Rest\Resources\BelongsToResource;
@@ -1131,6 +1133,338 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
                     'tags' => [],
                 ],
             ]
+        );
+    }
+
+    public function test_including_nested_relation_with_a_dotted_path_applies_selects_to_the_deepest_relation(): void
+    {
+        $belongsTo = BelongsToRelationFactory::new()->create();
+        ModelFactory::new()->for($belongsTo)->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        [
+                            'relation' => 'belongsToRelation.models',
+                            'selects'  => [['field' => 'id']],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        // The intermediate relation keeps the fields of its resource, the deepest one is narrowed.
+        $this->assertSame(
+            (new BelongsToResource())->getFields(app()->make(RestRequest::class)),
+            array_keys(Arr::except($response->json('data.0.belongs_to_relation'), ['models']))
+        );
+        $this->assertSame(
+            [['id' => 1]],
+            $response->json('data.0.belongs_to_relation.models')
+        );
+    }
+
+    public function test_including_nested_relation_with_a_deep_dotted_path_applies_selects_to_the_deepest_relation(): void
+    {
+        $belongsTo = BelongsToRelationFactory::new()->create();
+        ModelFactory::new()
+            ->for($belongsTo)
+            ->has(HasManyRelationFactory::new())
+            ->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        [
+                            'relation' => 'belongsToRelation.models.hasManyRelation',
+                            'selects'  => [['field' => 'id']],
+                        ],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        // Only the deepest relation of the path is narrowed, every level above keeps its fields.
+        $this->assertSame(
+            (new ModelResource())->getFields(app()->make(RestRequest::class)),
+            array_keys(Arr::except($response->json('data.0.belongs_to_relation.models.0'), ['has_many_relation']))
+        );
+        $this->assertSame(
+            [['id' => 1]],
+            $response->json('data.0.belongs_to_relation.models.0.has_many_relation')
+        );
+    }
+
+    public function test_including_relation_with_alias_hydrates_every_parent(): void
+    {
+        ModelFactory::new()
+            ->count(3)
+            ->has(HasManyRelationFactory::new()->count(2))
+            ->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'hasManyRelation', 'alias' => 'kids'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+        $this->assertSame(
+            [2, 2, 2],
+            array_map(fn ($model) => count($model['kids']), $response->json('data'))
+        );
+    }
+
+    public function test_including_belongs_to_relation_with_alias_hydrates_every_parent(): void
+    {
+        foreach (range(1, 3) as $ignored) {
+            ModelFactory::new()
+                ->for(BelongsToRelationFactory::new()->create())
+                ->create();
+        }
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'belongsToRelation', 'alias' => 'owner'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+        $this->assertSame(
+            [1, 2, 3],
+            array_map(fn ($model) => $model['owner']['id'], $response->json('data'))
+        );
+    }
+
+    public function test_including_morph_to_relation_with_alias(): void
+    {
+        $morphTo = MorphToRelationFactory::new()->create();
+        ModelFactory::new()
+            ->count(2)
+            ->state([
+                'morph_to_relation_type' => MorphToRelation::class,
+                'morph_to_relation_id'   => $morphTo->id,
+            ])
+            ->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(MorphToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'morphToRelation', 'alias' => 'morphed'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        foreach ($response->json('data') as $model) {
+            $this->assertSame($morphTo->id, $model['morphed']['id']);
+            $this->assertArrayNotHasKey('morph_to_relation', $model);
+        }
+    }
+
+    public function test_including_relation_both_natively_and_aliased(): void
+    {
+        ModelFactory::new()
+            ->count(2)
+            ->has(HasManyRelationFactory::new()->count(2))
+            ->create();
+
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'hasManyRelation'],
+                        ['relation' => 'hasManyRelation', 'alias' => 'kids'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        foreach ($response->json('data') as $model) {
+            $this->assertCount(2, $model['has_many_relation']);
+            $this->assertCount(2, $model['kids']);
+        }
+    }
+
+    public function test_including_relation_with_alias_on_a_nested_relation(): void
+    {
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'belongsToRelation.models', 'alias' => 'linkedModels'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.includes.0.alias']]);
+    }
+
+    public function test_including_relation_with_alias_conflicting_with_a_field(): void
+    {
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'hasManyRelation', 'alias' => 'name'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.includes.0.alias']]);
+    }
+
+    public function test_including_relation_with_alias_conflicting_with_the_gates_key(): void
+    {
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'gates'    => ['view'],
+                    'includes' => [
+                        ['relation' => 'hasManyRelation', 'alias' => config('rest.gates.key')],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.includes.0.alias']]);
+    }
+
+    public function test_including_relation_with_alias_conflicting_with_a_relation(): void
+    {
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+        Gate::policy(BelongsToRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'belongsToRelation'],
+                        ['relation' => 'hasManyRelation', 'alias' => 'belongsToRelation'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.includes.1.alias']]);
+    }
+
+    public function test_including_relation_with_a_non_identifier_alias(): void
+    {
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'hasManyRelation', 'alias' => '0'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(['message', 'errors' => ['search.includes.0.alias']]);
+    }
+
+    public function test_including_the_same_relation_twice_under_the_same_alias(): void
+    {
+        Gate::policy(Model::class, GreenPolicy::class);
+        Gate::policy(HasManyRelation::class, GreenPolicy::class);
+
+        $response = $this->post(
+            '/api/models/search',
+            [
+                'search' => [
+                    'includes' => [
+                        ['relation' => 'hasManyRelation', 'alias' => 'kids'],
+                        ['relation' => 'hasManyRelation', 'alias' => 'kids'],
+                    ],
+                ],
+            ],
+            ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(422);
+        $response->assertExactJsonStructure(
+            ['message', 'errors' => ['search.includes.0.alias', 'search.includes.1.alias']]
         );
     }
 }

--- a/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
+++ b/tests/Feature/Controllers/SearchIncludingRelationshipsOperationsTest.php
@@ -1139,7 +1139,7 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
     public function test_including_nested_relation_with_a_dotted_path_applies_selects_to_the_deepest_relation(): void
     {
         $belongsTo = BelongsToRelationFactory::new()->create();
-        ModelFactory::new()->for($belongsTo)->create();
+        $matchingModel = ModelFactory::new()->for($belongsTo)->create();
 
         Gate::policy(Model::class, GreenPolicy::class);
         Gate::policy(BelongsToRelation::class, GreenPolicy::class);
@@ -1167,7 +1167,7 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
             array_keys(Arr::except($response->json('data.0.belongs_to_relation'), ['models']))
         );
         $this->assertSame(
-            [['id' => 1]],
+            [['id' => $matchingModel->id]],
             $response->json('data.0.belongs_to_relation.models')
         );
     }
@@ -1175,7 +1175,7 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
     public function test_including_nested_relation_with_a_deep_dotted_path_applies_selects_to_the_deepest_relation(): void
     {
         $belongsTo = BelongsToRelationFactory::new()->create();
-        ModelFactory::new()
+        $matchingModel = ModelFactory::new()
             ->for($belongsTo)
             ->has(HasManyRelationFactory::new())
             ->create();
@@ -1207,7 +1207,7 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
             array_keys(Arr::except($response->json('data.0.belongs_to_relation.models.0'), ['has_many_relation']))
         );
         $this->assertSame(
-            [['id' => 1]],
+            [['id' => $matchingModel->hasManyRelation->first()->id]],
             $response->json('data.0.belongs_to_relation.models.0.has_many_relation')
         );
     }
@@ -1243,11 +1243,16 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
 
     public function test_including_belongs_to_relation_with_alias_hydrates_every_parent(): void
     {
-        foreach (range(1, 3) as $ignored) {
-            ModelFactory::new()
-                ->for(BelongsToRelationFactory::new()->create())
-                ->create();
-        }
+        // Each model gets its own distinct parent, so a leaking constraint cannot go unnoticed.
+        $expectedOwnerIds = collect(range(1, 3))
+            ->map(function () {
+                return ModelFactory::new()
+                    ->for(BelongsToRelationFactory::new()->create())
+                    ->create()
+                    ->belongsToRelation
+                    ->id;
+            })
+            ->all();
 
         Gate::policy(Model::class, GreenPolicy::class);
         Gate::policy(BelongsToRelation::class, GreenPolicy::class);
@@ -1266,7 +1271,7 @@ class SearchIncludingRelationshipsOperationsTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertSame(
-            [1, 2, 3],
+            $expectedOwnerIds,
             array_map(fn ($model) => $model['owner']['id'], $response->json('data'))
         );
     }


### PR DESCRIPTION
Closes #226

Includes now accept an optional `alias`. When set, the relation is loaded manually under the alias key (via afterQuery + Eloquent's match/initRelation), which lets the same relation be included several times with distinct constraints — impossible with native eager loading, keyed by relation name.

The response builder now matches includes by exact key instead of a regex, and uses the alias verbatim as the output key.